### PR TITLE
Update vnext Tools doc

### DIFF
--- a/apps/web/content/vnext/overview/tools.mdx
+++ b/apps/web/content/vnext/overview/tools.mdx
@@ -2,7 +2,7 @@
 title: Tools
 ---
 
-Tools enable Hydra to interact with your application's data and functionality. They provide a type-safe way to extend the AI's capabilities with custom business logic. Hydra will call these tools and use their outputs to information to help decide how to respond to a message, what component to choose, and what data to fill the component with.
+Tools enable Hydra to interact with your application's data and functionality. They provide a type-safe way to extend the AI's capabilities with custom business logic. Hydra will call these tools and use their outputs to help decide how to respond to a message, what component to show, and what data to fill the component with.
 
 ```tsx
 interface HydraTool {
@@ -13,10 +13,10 @@ interface HydraTool {
 }
 ```
 
-To make use of tools, we will:
+**To make use of tools, we will:**
 
 1. Add tools by defining them and registering them with Hydra
-2. Tie tools to components, so Hydra know which tools to focus on when using a given component
+2. Associate tools with components, so Hydra know which tools to focus on when using a given component
 
 ## Adding a Tool
 
@@ -48,7 +48,7 @@ const tool: HydraTool = {
 hydraClient.registerTool(tool);
 ```
 
-### Registering a Tool using React Hooks
+**Registering a Tool using React Hooks:**
 
 ```tsx
 const { registerTool, registerTools } = useHydra();
@@ -63,7 +63,7 @@ registerTools([tool1, tool2]); // register multiple tools at once
 
 Once Hydra has decided on a component to use in response to a message, it will use the registered tools if it has decided that extra external data is needed to fill the component properly. To tell Hydra which tools to consider for a given component, we need to associate the tools with the component. A tool can be associated with multiple components.
 
-During component definition:
+**During component definition:**
 
 If you already have the tool functionality defined when you register your components, you can pass the tool directly to the component definition.
 
@@ -79,7 +79,7 @@ hydraClient.registerComponent({
 });
 ```
 
-Using React Hooks:
+**Using React Hooks:**
 
 If you define your tool functionality sometime after registering your components, you can use the `addToolAssociation` hook to associate the tool with the component.
 


### PR DESCRIPTION
Updates the VNext doc page for Tools in an attempt to solidify what a dev should expect in terms of interface for:

- HydraTool type
- HydraTool definition
- HydraTool registration using methods and hooks
- Association of tools to components, during component definition or later using hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated and streamlined guidance on integrating external tools with Hydra, clarifying their role in driving AI responses, component selection, and data population.
  - Revised instructions for defining, registering, and associating tools, with improved examples and error handling tips.

- **New Features**
  - Introduced an enhanced registration process that supports both individual and multiple tool registrations, offering greater flexibility in tool integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->