### PR TITLE
fix: do not show json thread

### DIFF
--- a/apps/web/app/internal/smoketest/page.tsx
+++ b/apps/web/app/internal/smoketest/page.tsx
@@ -186,9 +186,6 @@ export default function SmokePage() {
       <div>
         <p>Thread ID: &apos;{thread.id}&apos;</p>
       </div>
-      <div>
-        <pre>Thread: {JSON.stringify(thread, null, 2)}</pre>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the display of raw thread details from the page, streamlining the user interface.
  - All existing functionalities—such as message handling and error notifications—continue to operate as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->