### PR TITLE
fix: include the threadId in the ThreadMessage

### DIFF
--- a/apps/api/src/threads/dto/message.dto.ts
+++ b/apps/api/src/threads/dto/message.dto.ts
@@ -55,6 +55,7 @@ interface InternalThreadMessage {
 }
 export class ThreadMessage implements InternalThreadMessage {
   id!: string;
+  threadId!: string;
   @IsEnum(MessageRole)
   role!: MessageRole;
   content!: ChatCompletionContentPart[];

--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -106,6 +106,7 @@ export class ThreadsService {
     });
     return {
       id: message.id,
+      threadId,
       role: message.role,
       content: convertContentPartToDto(message.content),
       metadata: message.metadata ?? undefined,
@@ -120,6 +121,7 @@ export class ThreadsService {
     return messages.map(
       (message): ThreadMessage => ({
         id: message.id,
+        threadId,
         role: message.role,
         content: convertContentPartToDto(message.content),
         metadata: message.metadata ?? undefined,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced messaging responses to include a mandatory thread identifier, ensuring each message is clearly associated with its respective conversation thread.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->