### PR TITLE
fix: properly format slack notification on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,20 +46,38 @@ jobs:
         uses: slackapi/slack-github-action@v2.0.0
         with:
           payload: |
-            blocks:
-              - type: header
-                text:
-                  type: plain_text
-                  text: ":rocket: Production Deployment Started"
-              - type: section
-                fields:
-                  - type: mrkdwn
-                    text: "*Version*\n${{ steps.release.outputs.tag_name }}"
-                  - type: mrkdwn
-                    text: "*Release PR*\nhttps://github.com/${{ github.repository }}/pull/${{ fromJson(steps.release.outputs.pr).number }}"
-              - type: section
-                fields:
-                  - type: mrkdwn
-                    text: "*Triggered by*\n${{ github.actor }}"
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":rocket: Production Deployment Started"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Version*\n${{ steps.release.outputs.tag_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Release PR*\nhttps://github.com/${{ github.repository }}/pull/${{ fromJson(steps.release.outputs.pr).number }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Triggered by*\n${{ github.actor }}"
+                    }
+                  ]
+                }
+              ]
+            }
         env:
           SLACK_WEBHOOK_URL: ${{ vars.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- **fix block format for releases**
- **switch to json so I can use block bluilder**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Slack deployment notifications now display clear, organized information such as version details, release links, and the triggering actor for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->