### PR TITLE
fix: use ApiQuery to indicate a query param, not a path param

### DIFF
--- a/apps/api/src/threads/threads.controller.ts
+++ b/apps/api/src/threads/threads.controller.ts
@@ -98,7 +98,7 @@ export class ThreadsController {
   // @UseGuards(ProjectAccessOwnGuard)
   // TODO: Not protected by project access guard
   @Get(':id/messages')
-  @ApiParam({
+  @ApiQuery({
     name: 'includeInternal',
     description: 'Whether to include internal messages',
     required: false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the API specification for the threads messaging endpoint by revising the "includeInternal" parameter to be treated as a query parameter, enhancing clarity for API consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->