### PR TITLE
fix: Return component name with streamed toolcallrequest

### DIFF
--- a/apps/api/src/components/components.controller.ts
+++ b/apps/api/src/components/components.controller.ts
@@ -238,9 +238,19 @@ export class ComponentsController {
         true,
       );
 
-      //TODO: add 'in-progress' message to thread and update on each chunk
       for await (const chunk of stream) {
-        response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+        //TODO: don't create threadmessage here, add 'in-progress' message to thread and update on each chunk
+        const threadMessage: ThreadMessage = {
+          role: MessageRole.Hydra,
+          content: [{ type: ContentPartType.Text, text: chunk.message }],
+          id: new Date().toISOString(),
+          threadId: resolvedThreadId,
+          component: chunk,
+          createdAt: new Date(),
+          actionType: chunk.toolCallRequest ? ActionType.ToolCall : undefined,
+          toolCallRequest: chunk.toolCallRequest,
+        };
+        response.write(`data: ${JSON.stringify(threadMessage)}\n\n`);
       }
     } catch (error: any) {
       this.logger.error('Error in generateComponentStream:', error);
@@ -436,9 +446,19 @@ export class ComponentsController {
     );
 
     try {
-      //TODO: add 'in-progress' message to thread and update on each chunk
       for await (const chunk of stream) {
-        response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+        //TODO: don't create threadmessage here, add 'in-progress' message to thread and update on each chunk
+        const threadMessage: ThreadMessage = {
+          role: MessageRole.Hydra,
+          content: [{ type: ContentPartType.Text, text: chunk.message }],
+          id: new Date().toISOString(),
+          threadId: resolvedThreadId,
+          component: chunk,
+          createdAt: new Date(),
+          actionType: chunk.toolCallRequest ? ActionType.ToolCall : undefined,
+          toolCallRequest: chunk.toolCallRequest,
+        };
+        response.write(`data: ${JSON.stringify(threadMessage)}\n\n`);
       }
     } catch (error: any) {
       this.logger.error('Error in hydrateComponentStream:', error);

--- a/packages/hydra-ai-server/src/hydra-ai/services/component/component-hydration-service.ts
+++ b/packages/hydra-ai-server/src/hydra-ai/services/component/component-hydration-service.ts
@@ -88,7 +88,12 @@ export async function hydrateComponent(
       stream: true,
     });
 
-    return handleComponentHydrationStream(responseStream, threadId, version);
+    return handleComponentHydrationStream(
+      responseStream,
+      chosenComponent.name,
+      threadId,
+      version,
+    );
   }
 
   const generateComponentResponse = await llmClient.complete(completeOptions);
@@ -121,11 +126,12 @@ export async function hydrateComponent(
 
 async function* handleComponentHydrationStream(
   responseStream: AsyncIterableIterator<OpenAIResponse>,
+  componentName: string,
   threadId: string,
   version: "v1" | "v2" = "v1",
 ): AsyncIterableIterator<ComponentDecision> {
   const initialDecision: ComponentDecision = {
-    componentName: null,
+    componentName,
     props: null,
     message: "",
     ...(version === "v1" ? { suggestedActions: [] } : {}),


### PR DESCRIPTION
Streamed toolcallrequest was not previously including chosen component name which caused problems clientside.

Also, formats the response type for stream routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced streaming responses to include richer context details and clearer message structures.
	- Updated how component identifiers are handled during data streaming, ensuring improved clarity and consistency in component updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->