### PR TITLE
fix: Revert "deps: make dependabot use "deps" as per release-please"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,8 @@ updates:
       day: "monday"
     open-pull-requests-limit: 10
     commit-message:
-      prefix: "deps"
-      prefix-development: "deps"
+      prefix: "chore"
+      prefix-development: "chore"
       include: "scope"
     groups:
       trpc:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -15,4 +15,4 @@ jobs:
       - name: PR Conventional Commit Validation
         uses: ytanikin/pr-conventional-commits@1.4.0
         with:
-          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert", "deps"]'
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'


### PR DESCRIPTION
release-please docs are not up to date..

Reverts use-hydra-ai/hydra-ai-site#318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized commit message prefixes for dependency updates to improve consistency.
  - Updated commit message validation rules to streamline workflow oversight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->