### PR TITLE
fix: avoid resetting ID every chunk of streamed ThreadMessage

### DIFF
--- a/apps/api/src/components/components.controller.ts
+++ b/apps/api/src/components/components.controller.ts
@@ -238,12 +238,14 @@ export class ComponentsController {
         true,
       );
 
+      const tempId = new Date().toISOString();
+
       for await (const chunk of stream) {
         //TODO: don't create threadmessage here, add 'in-progress' message to thread and update on each chunk
         const threadMessage: ThreadMessage = {
           role: MessageRole.Hydra,
           content: [{ type: ContentPartType.Text, text: chunk.message }],
-          id: new Date().toISOString(),
+          id: tempId,
           threadId: resolvedThreadId,
           component: chunk,
           createdAt: new Date(),
@@ -446,12 +448,13 @@ export class ComponentsController {
     );
 
     try {
+      const tempId = new Date().toISOString();
       for await (const chunk of stream) {
         //TODO: don't create threadmessage here, add 'in-progress' message to thread and update on each chunk
         const threadMessage: ThreadMessage = {
           role: MessageRole.Hydra,
           content: [{ type: ContentPartType.Text, text: chunk.message }],
-          id: new Date().toISOString(),
+          id: tempId,
           threadId: resolvedThreadId,
           component: chunk,
           createdAt: new Date(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the streaming process for message delivery by ensuring consistent identification for all messages during a session.
  - This enhancement streamlines message tracking and contributes to a more reliable real-time experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->