### PR TITLE
fix: Avoid hydration stream flicker

### DIFF
--- a/packages/hydra-ai-server/src/hydra-ai/services/component/component-hydration-service.ts
+++ b/packages/hydra-ai-server/src/hydra-ai/services/component/component-hydration-service.ts
@@ -152,6 +152,8 @@ async function* handleComponentHydrationStream(
       accumulatedDecision = {
         ...accumulatedDecision,
         ...parsedChunk,
+        componentName,
+        threadId,
       };
 
       yield accumulatedDecision;


### PR DESCRIPTION
Fixes a problem where the hydration stream would wait for the LLM response to build the component name during chunk streaming.

Frontend would already have the component name from the generation request, and would then get the 'empty' componentname from the first few hydration chunks, causing it to show the component, then show nothing, then quickly show the component again once the hydration chunks built the component name again.

Instead, just forces hydration stream to return the chosen component name from the first chunk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the processing logic by including context-related details, such as component and thread identifiers, in the accumulated results. This enhancement provides more consistent and traceable output for decision tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->