### PR TITLE
fix: use generic "items", not "threads" so pagination is generic

### DIFF
--- a/apps/api/src/threads/dto/thread.dto.ts
+++ b/apps/api/src/threads/dto/thread.dto.ts
@@ -52,4 +52,5 @@ export class ThreadListDto {
   total!: number;
   offset!: number;
   limit!: number;
+  count!: number;
 }

--- a/apps/api/src/threads/threads.controller.ts
+++ b/apps/api/src/threads/threads.controller.ts
@@ -74,10 +74,11 @@ export class ThreadsController {
     const threads = await threadsPromise;
     const total = await totalPromise;
     return {
-      items: threads,
       total,
       offset,
       limit,
+      count: threads.length,
+      items: threads,
     };
   }
 


### PR DESCRIPTION
Makes it easier to do generic pagination with stainless APIs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the API’s thread list structure by renaming the key from "threads" to "items" for improved consistency in responses. This change maintains the overall data structure while providing a clearer naming convention for consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->