### PR TITLE
fix: bump body size limit

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,6 +1,7 @@
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule } from '@nestjs/swagger';
+import { json, urlencoded } from 'express';
 import { AppModule } from './app.module';
 import { generateOpenAPIConfig } from './common/openapi';
 
@@ -8,6 +9,8 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule, { cors: true });
   app.useGlobalPipes(new ValidationPipe({ transform: true }));
   configureSwagger(app);
+  app.use(json({ limit: '1mb' }));
+  app.use(urlencoded({ extended: true, limit: '1mb' }));
   await app.listen(process.env.PORT || 3000);
 }
 


### PR DESCRIPTION
nest default body size limit was 100kb. With the tool response data from smoketest weather api our request was about 97kb, and when using 'advance' was bumped a few kb to go over the limit.

Super hacky fix for now just updates limit to 1mb 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced application support for JSON requests with a maximum body size of 1MB.
	- Improved handling of URL-encoded requests with a 1MB payload limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->