### PR TITLE
fix: thread stage during streaming

### DIFF
--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -541,6 +541,12 @@ export class ThreadsService {
     let lastUpdateTime = 0;
     const updateIntervalMs = 500;
 
+    await this.updateGenerationStage(
+      threadId,
+      GenerationStage.STREAMING_RESPONSE,
+      `Streaming response...`,
+    );
+
     const inProgressMessage = await this.addMessage(threadId, {
       role: MessageRole.Hydra,
       content: [
@@ -595,14 +601,23 @@ export class ThreadsService {
         inProgressMessage.id,
         finalResponse.responseMessageDto,
       );
+      const resultingGenerationStage = finalResponse.responseMessageDto
+        .toolCallRequest
+        ? GenerationStage.FETCHING_CONTEXT
+        : GenerationStage.COMPLETE;
+      const resultingStatusMessage = finalResponse.responseMessageDto
+        .toolCallRequest
+        ? `Fetching context...`
+        : `Complete`;
+      await this.updateGenerationStage(
+        threadId,
+        resultingGenerationStage,
+        resultingStatusMessage,
+      );
       yield {
         responseMessageDto: finalResponse.responseMessageDto,
-        generationStage: finalResponse.responseMessageDto.toolCallRequest
-          ? GenerationStage.FETCHING_CONTEXT
-          : GenerationStage.COMPLETE,
-        statusMessage: finalResponse.responseMessageDto.toolCallRequest
-          ? `Fetching context...`
-          : `Complete`,
+        generationStage: resultingGenerationStage,
+        statusMessage: resultingStatusMessage,
       };
     }
   }


### PR DESCRIPTION
Previously was not updating thread's generationstage/status during streaming.

Was slightly hidden because clientside would update its own stage correctly sometimes, but not always.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced progress updates during asynchronous operations, providing consistent, real-time status messages that indicate when responses are streaming, when context is being fetched, and when processes are complete. This improvement delivers clearer feedback for users throughout the operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->