### PR TITLE
fix: add component info and state to llm message history only when needed

### DIFF
--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -717,23 +717,20 @@ function convertThreadMessagesToLegacyThreadMessages(
       sender: [MessageRole.User, MessageRole.Tool].includes(message.role)
         ? (message.role as 'user' | 'tool')
         : 'hydra',
-      message:
-        message.content
-          .map((part) => {
-            switch (part.type) {
-              case ContentPartType.Text:
-                return part.text ?? '';
-              default:
-                return '';
-            }
-          })
-          .join('') +
-        ' ' +
-        JSON.stringify({
-          component:
-            message.componentDecision ?? message.component ?? undefined,
-          componentState: message.componentState ?? undefined,
-        }),
+      message: message.content
+        .map((part) => {
+          switch (part.type) {
+            case ContentPartType.Text:
+              return part.text ?? '';
+            default:
+              return '';
+          }
+        })
+        .join(''),
+      componentDecision:
+        message.componentDecision?.componentName && message.componentDecision,
+      componentState: message.componentState,
+      actionType: message.actionType,
     }),
   );
 }

--- a/packages/hydra-ai-server/src/hydra-ai/model/chat-message.ts
+++ b/packages/hydra-ai-server/src/hydra-ai/model/chat-message.ts
@@ -1,5 +1,10 @@
+import { ActionType, ComponentDecisionV2 } from "@tambo-ai-cloud/core";
+
 export interface ChatMessage {
   sender: "hydra" | "user" | "tool";
   message: string;
   additionalContext?: string;
+  componentDecision?: ComponentDecisionV2;
+  componentState?: Record<string, unknown>;
+  actionType?: ActionType;
 }

--- a/packages/hydra-ai-server/src/hydra-ai/services/llm/utils.ts
+++ b/packages/hydra-ai-server/src/hydra-ai/services/llm/utils.ts
@@ -4,12 +4,24 @@ import { ChatMessage } from "../../model/chat-message";
 export function chatHistoryToParams(
   messageHistory: ChatMessage[],
 ): ChatCompletionMessageParam[] {
-  return messageHistory.map((message) => ({
-    role: ["user", "tool"].includes(message.sender) ? "user" : "assistant",
-    content:
-      message.message +
-      (message.additionalContext
-        ? `<System> The following is additional context provided by the system that you can use when responding to the user:  ${message.additionalContext} </System>`
-        : ""),
-  }));
+  console.log("messageHistory", messageHistory);
+  return messageHistory.map((message) => {
+    let content = message.message;
+
+    if (message.componentDecision && !message.actionType) {
+      content += `\n<Component>${JSON.stringify(message.componentDecision)}</Component>`;
+    }
+    if (message.componentState && !message.actionType) {
+      content += `\n<ComponentState>${JSON.stringify(message.componentState)}</ComponentState>`;
+    }
+
+    if (message.additionalContext) {
+      content += `<System> The following is additional context provided by the system that you can use when responding to the user: ${message.additionalContext} </System>`;
+    }
+
+    return {
+      role: ["user", "tool"].includes(message.sender) ? "user" : "assistant",
+      content,
+    };
+  });
 }


### PR DESCRIPTION
Instead of adding extra content to each message sent to the LLM, updates ChatMessage and builds LLM messages based on fields of that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced how conversation messages are constructed to include additional context and detail.
  - Improved the processing of thread and chat messages, ensuring that users see clearer and more accurate content during interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->