### PR TITLE
chore: stream message first

### DIFF
--- a/packages/hydra-ai-server/src/hydra-ai/services/prompt/schemas.ts
+++ b/packages/hydra-ai-server/src/hydra-ai/services/prompt/schemas.ts
@@ -1,17 +1,17 @@
 import { z } from "zod";
 
 const baseSchema = {
+  message: z
+    .string()
+    .describe(
+      "The message to be displayed to the user alongside the chosen component. Depending on the component type, and the user message, this message might include a description of why a given component was chosen, and what can be seen within it, or what it does.",
+    ),
   componentName: z.string().describe("The name of the chosen component"),
   props: z
     .object({})
     .passthrough()
     .describe(
       "The props that should be used in the chosen component. These will be injected by using React.createElement(component, props)",
-    ),
-  message: z
-    .string()
-    .describe(
-      "The message to be displayed to the user alongside the chosen component. Depending on the component type, and the user message, this message might include a description of why a given component was chosen, and what can be seen within it, or what it does.",
     ),
   reasoning: z.string().describe("The reasoning behind the decision"),
 };


### PR DESCRIPTION
Updates response schema to have llm generate the "message" part first, so during a stream response the user will see the message first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Made internal adjustments to our schema configuration to enhance consistency and maintainability, with no changes affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->