### PR TITLE
fix: use global pool, local drizzle instance

### DIFF
--- a/apps/api/src/common/middleware/db-transaction-middleware.ts
+++ b/apps/api/src/common/middleware/db-transaction-middleware.ts
@@ -58,7 +58,7 @@ export class TransactionMiddleware implements NestMiddleware {
     }
 
     console.log(
-      `[${requestSerialNumber}] starting transaction ${this.db.$client.totalCount} connections (${this.db.$client.idleCount} idle)`,
+      `[${requestSerialNumber}] starting transaction ${this.db.$client.totalCount} connections (${this.db.$client.idleCount} idle) with ${req.method} ${req.url}`,
     );
     const p = this.db.transaction(async (tx) => {
       console.log(


### PR DESCRIPTION
- **bump pool to 30 connections as a test**
- **add some logging**
- **use a global pool but create new drizzle each time**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced logging now captures additional request details for improved monitoring.
  
- **Refactor**
  - Upgraded database connection management with a pooling strategy to boost performance and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->