### PR TITLE
fix: pass along contextKey when creating thread

### DIFF
--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -432,7 +432,11 @@ export class ThreadsService {
   ): Promise<
     AdvanceThreadResponseDto | AsyncIterableIterator<AdvanceThreadResponseDto>
   > {
-    const thread = await this.ensureThread(projectId, threadId, undefined);
+    const thread = await this.ensureThread(
+      projectId,
+      threadId,
+      advanceRequestDto.contextKey,
+    );
 
     // Ensure only one request per thread adds its user message and continues
     const addedUserMessage = await this.getDb().transaction(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced thread processing by incorporating additional context provided by the client, ensuring more accurate management and retrieval of conversation threads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->