### PR TITLE
fix: include full component decision in chat history when sending to llm

### DIFF
--- a/apps/api/src/threads/threads.controller.ts
+++ b/apps/api/src/threads/threads.controller.ts
@@ -129,6 +129,9 @@ export class ThreadsController {
     @Param("id") threadId: string,
     @Body() messageDto: MessageRequest,
   ) {
+    if (!["user", "tool"].includes(messageDto.role)) {
+      console.warn(`Received message with role ${messageDto.role}`, messageDto);
+    }
     return await this.threadsService.addMessage(threadId, messageDto);
   }
 

--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -888,11 +888,22 @@ export class ThreadsService {
     component: LegacyComponentDecision,
     tx?: HydraTransaction,
   ) {
+    // Make sure to only include the fields that are needed for message history
+    const serializedMessage: ComponentDecisionV2 = {
+      message: component.message,
+      componentName: component.componentName,
+      props: component.props,
+    };
     return await this.addMessage(
       threadId,
       {
         role: MessageRole.Assistant,
-        content: [{ type: ContentPartType.Text, text: component.message }],
+        content: [
+          {
+            type: ContentPartType.Text,
+            text: JSON.stringify(serializedMessage),
+          },
+        ],
         component: component,
         actionType: component.toolCallRequest ? ActionType.ToolCall : undefined,
         toolCallRequest: component.toolCallRequest,


### PR DESCRIPTION
previously we'd only store the message like "Here is the AQI for berkeley" instead of the full JSON that the LLM returned us originally

That meant that as the thread grew longer, the LLM was less likely to actually return a working component decision, because previous examples just returned text
