### PR TITLE
fix: store basic message in the db, but reconstitute the message history based on component history/etc

### DIFF
--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -901,10 +901,10 @@ export class ThreadsService {
         content: [
           {
             type: ContentPartType.Text,
-            text: JSON.stringify(serializedMessage),
+            text: component.message,
           },
         ],
-        component: component,
+        component: serializedMessage,
         actionType: component.toolCallRequest ? ActionType.ToolCall : undefined,
         toolCallRequest: component.toolCallRequest,
         tool_call_id: component.toolCallRequest?.tool_call_id,
@@ -955,10 +955,12 @@ function convertContentDtoToContentPart(
 function threadMessageDtoToThreadMessage(
   messages: ThreadMessageDto[],
 ): ThreadMessage[] {
-  return messages.map((message) => ({
-    ...message,
-    content: convertContentDtoToContentPart(message.content),
-  }));
+  return messages.map(
+    (message): ThreadMessage => ({
+      ...message,
+      content: convertContentDtoToContentPart(message.content),
+    }),
+  );
 }
 
 function convertContentPartToDto(

--- a/packages/core/src/threads.ts
+++ b/packages/core/src/threads.ts
@@ -104,6 +104,10 @@ export interface ThreadMessage {
 
   /** Used only when role === "tool" */
   tool_call_id?: string;
+  /**
+   * The tool call request for the message
+   */
+  toolCallRequest?: ToolCallRequest;
 }
 
 /** Temporary internal type to make sure that subclasses are aligned on types */


### PR DESCRIPTION
fixes occasional 500 errors on the 2nd message in a thread


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for an optional tool call request in messages, broadening interaction capabilities.

- **Enhancements**
  - Improved conversation thread processing for clearer, more direct message content display.
  - Refined the chat history assembly to better manage assistant responses and tool integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->