### PR TITLE
fix: add a generous 10s connection timeout to try to diagnose railway issues

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -14,6 +14,7 @@ function getDb(databaseUrl: string): HydraDatabase {
     const pool = new Pool({
       connectionString: databaseUrl,
       max: MAX_POOL_SIZE,
+      connectionTimeoutMillis: 10000,
     });
 
     pool.on("acquire", () => {


### PR DESCRIPTION
For production this should probably be more like 1s or 2s, but we'll ramp it down after diagnosing what is going on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable timeout for database connection attempts, setting a maximum wait period of 10 seconds to improve connection reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->