### PR TITLE
docs: show jsonschema example in registration docs

### DIFF
--- a/apps/web/content/docs/concepts/registering-components.mdx
+++ b/apps/web/content/docs/concepts/registering-components.mdx
@@ -161,7 +161,7 @@ export const DataChartProps = z
     type: z
       .enum(["bar", "line", "pie"])
       .describe(
-        "Use a chart type that is appropriate for the data. Only use pie charts when less than 5 values."
+        "Use a chart type that is appropriate for the data. Only use pie charts when less than 5 values.",
       ),
   })
   .describe("A component for displaying data in various chart formats");

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "turbo lint",
     "lint:fix": "turbo lint -- --fix",
     "test": "turbo test",
-    "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "format": "prettier --write .",
     "prettier-check": "prettier --check .",
     "check-types": "turbo check-types",
     "hydra-api:start": "turbo run start --filter=hydra-api",


### PR DESCRIPTION
hides propsDefinition since now `propsSchema` can take zod or jsonschema, and shows jsonschema example