### PR TITLE
ci: make migrations run after "Build" step is done

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,10 +2,11 @@ name: Deploy Database Migrations
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["Build"]
     branches: [main]
     types:
       - completed
+  workflow_dispatch:
 
 jobs:
   deploy-migrations:


### PR DESCRIPTION
I don't have an easy way to make this run after multiple jobs have all completed, so "Build" is probably our best bet here
