### PR TITLE
feat: add standard tool param for completionStatusMessage

### DIFF
--- a/packages/backend/src/services/decision-loop/decision-loop-service.ts
+++ b/packages/backend/src/services/decision-loop/decision-loop-service.ts
@@ -74,6 +74,7 @@ export async function* runDecisionLoop(
     toolCallRequest: undefined,
     toolCallId: undefined,
     statusMessage: undefined,
+    completionStatusMessage: undefined,
   };
 
   let accumulatedDecision = initialDecision;
@@ -102,7 +103,7 @@ export async function* runDecisionLoop(
 
       const paramDisplayMessage = (toolArgs as any).displayMessage;
       const statusMessage = (toolArgs as any).statusMessage;
-
+      const completionStatusMessage = (toolArgs as any).completionStatusMessage;
       // If this is a non-UI tool call, make sure params are complete and filter out standard tool parameters
       let filteredToolCallRequest;
       if (!isUITool && toolCall) {
@@ -149,6 +150,7 @@ export async function* runDecisionLoop(
             ? undefined
             : getLLMResponseToolCallId(chunk),
         statusMessage,
+        completionStatusMessage,
       };
 
       accumulatedDecision = {

--- a/packages/backend/src/services/tool/tool-service.ts
+++ b/packages/backend/src/services/tool/tool-service.ts
@@ -12,7 +12,12 @@ export const standardToolParameters: FunctionParameters = {
     statusMessage: {
       type: "string",
       description:
-        "a message that will be displayed to the user to explain in a few words what the tool is being used for, starting with a verb. For example, 'looking for <something>' or 'creating <something>'.",
+        "A message that will be displayed to the user to explain in a few words what the tool is being used for, starting with a verb. For example, 'looking for <something>' or 'creating <something>'.",
+    },
+    completionStatusMessage: {
+      type: "string",
+      description:
+        "A message that will be displayed to the user to explain in a few words what the tool has done, to replace the statusMessage when the tool has completed its task. For example, 'looked for <something>' or 'created <something>'",
     },
     displayMessage: {
       type: "string",
@@ -20,7 +25,7 @@ export const standardToolParameters: FunctionParameters = {
         "A message to be displayed before the tool is called. This should be a natural language response to the previous message to describe what you are about to do. For example, `First, let me <do something>` or 'Great, I can see <something>, let me <do something>'. Get creative, this is what will make the user feel like they are having a conversation with you. You can and should use markdown formatting (code blocks with language specification, bold, lists) when showing examples or code.",
     },
   },
-  required: ["statusMessage", "displayMessage"],
+  required: ["statusMessage", "displayMessage", "completionStatusMessage"],
   additionalProperties: false,
 };
 

--- a/packages/core/src/ComponentDecision.ts
+++ b/packages/core/src/ComponentDecision.ts
@@ -8,6 +8,7 @@ export interface LegacyComponentDecision {
   componentState: Record<string, unknown> | null;
   reasoning: string;
   statusMessage?: string;
+  completionStatusMessage?: string;
 }
 
 export interface ComponentDecisionV2 {


### PR DESCRIPTION
For each toolcall, LLM will generate a 'completionStatusMessage' that we can replace the 'statusMessage' with when the tool action completes.

For example, statusMessage -> completionStatusMessage:
'looking for coffee makers' -> 'looked for coffee makers'
'creating a new entry' -> 'created a new entry'