### PR TITLE
fix: still call tools even without parameters

### DIFF
--- a/packages/backend/src/services/tool/tool-service.ts
+++ b/packages/backend/src/services/tool/tool-service.ts
@@ -46,11 +46,6 @@ export function convertMetadataToTools(
   toolsMetadata: ComponentContextToolMetadata[],
 ): OpenAI.Chat.Completions.ChatCompletionTool[] {
   return toolsMetadata.map((tool) => {
-    console.log(
-      "converting tool first param =",
-      tool.name,
-      tool.parameters[0].schema,
-    );
     const parameters = {
       type: "object",
       properties: {


### PR DESCRIPTION
- **allow for tools that take no parameters**
- **back this back out**
