### PR TITLE
fix: Make sure toolcallrequest chunks have actionType

### DIFF
--- a/apps/api/src/threads/util/thread-state.ts
+++ b/apps/api/src/threads/util/thread-state.ts
@@ -298,7 +298,6 @@ export async function* convertDecisionStreamToMessageStream(
         },
       ],
       component: chunk,
-      actionType: chunk.toolCallRequest ? ActionType.ToolCall : undefined,
       // do NOT set the toolCallRequest or tool_call_id here, we will set them in the final response
     };
     if (chunk.toolCallRequest) {
@@ -316,8 +315,8 @@ export async function* convertDecisionStreamToMessageStream(
     ...finalThreadMessage,
     toolCallRequest: finalToolCallRequest,
     tool_call_id: finalToolCallId,
+    actionType: finalToolCallRequest ? ActionType.ToolCall : undefined,
   };
-
   yield finalThreadMessage;
 }
 


### PR DESCRIPTION
Previously we were setting actionType to tool_call or undefined depending on whether the chunk has a toolcallrequest or not. Sometimes a chunk would have one, but would be followed by one that does not include a toolcallrequest, so we end up with a final streamed object that has a toolcallrequest but actionType is undefined.

Updated to set actiontype at the end when we set the toolcallrequest