### PR TITLE
fix: yield tool call request for server-side tool message

### DIFF
--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -882,8 +882,6 @@ export class ThreadsService {
       const finalThreadMessageDto: AdvanceThreadResponseDto = {
         responseMessageDto: {
           ...finalThreadMessage,
-          content: convertContentPartToDto(finalThreadMessage.content),
-          componentState: finalThreadMessage.componentState ?? {},
           toolCallRequest: undefined,
           tool_call_id: undefined,
         },


### PR DESCRIPTION
this makes it so server-side tool calls still emit tool messages visible to the client components
