### PR TITLE
fix: make sure MCP oauth redirects to the right environment

### DIFF
--- a/apps/web/lib/base-url.tsx
+++ b/apps/web/lib/base-url.tsx
@@ -4,6 +4,9 @@ export function getBaseUrl() {
   if (typeof window !== "undefined") {
     return window.location.origin;
   }
+  if (env.NEXT_PUBLIC_APP_URL) {
+    return env.NEXT_PUBLIC_APP_URL;
+  }
   if (env.VERCEL_URL) {
     return `https://${env.VERCEL_URL}`;
   }

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -33,7 +33,7 @@ export const env = createEnv({
    * 💡 You'll get type errors if these are not prefixed with NEXT_PUBLIC_.
    */
   client: {
-    NEXT_PUBLIC_APP_URL: z.string().min(1).optional(),
+    NEXT_PUBLIC_APP_URL: z.string().url().optional(),
     NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
     NEXT_PUBLIC_SUPABASE_URL: z.string().min(1),
     NEXT_PUBLIC_POSTHOG_KEY: z.string().min(1).optional(),

--- a/apps/web/server/api/routers/tools.ts
+++ b/apps/web/server/api/routers/tools.ts
@@ -1,6 +1,5 @@
 import { getBaseUrl } from "@/lib/base-url";
 import { getComposio } from "@/lib/composio";
-import { env } from "@/lib/env";
 import { customHeadersSchema } from "@/lib/headerValidation";
 import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
 import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
@@ -577,9 +576,7 @@ async function getOAuthProvider(
   // If we have a user context with client info, use that directly
   if (userContext?.mcpOauthClientInfo) {
     return new OAuthLocalProvider(db, userContext.id, {
-      baseUrl: env.VERCEL_URL
-        ? `https://${env.VERCEL_URL}`
-        : "http://localhost:3000",
+      baseUrl: getBaseUrl(),
       serverUrl: url,
       clientInformation: userContext.mcpOauthClientInfo,
     });
@@ -611,9 +608,7 @@ async function getOAuthProvider(
   }
 
   return new OAuthLocalProvider(db, context.id, {
-    baseUrl: env.VERCEL_URL
-      ? `https://${env.VERCEL_URL}`
-      : "http://localhost:3000",
+    baseUrl: getBaseUrl(),
     serverUrl: url,
     clientInformation: client.sessionInfo.clientInformation,
     sessionId: client.sessionId,


### PR DESCRIPTION
In production, we were redirecting to the generated deployment url, not https://tambo.co