### PR TITLE
fix(api): use fallback OpenAI key when project has non-OpenAI provider keys

### DIFF
--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -1082,6 +1082,17 @@ export class ThreadsService {
       (key) => key.providerName === providerName,
     );
     if (!chosenKey) {
+      // Check for fallback key if OpenAI is requested
+      if (providerName === "openai") {
+        const fallbackKey = process.env.FALLBACK_OPENAI_API_KEY;
+        if (!fallbackKey) {
+          throw new NotFoundException(
+            `No OpenAI key found for project ${projectId} and no fallback key configured`,
+          );
+        }
+        return fallbackKey;
+      }
+
       throw new Error(
         `No key found for provider ${providerName} in project ${projectId}`,
       );


### PR DESCRIPTION


- Previously, fallback OpenAI API key was only used when projects had no provider keys at all. Now it's also used when projects have provider keys for other providers (Anthropic, etc.) but no OpenAI key configured.
- This ensures the fallback key works consistently regardless of what other provider keys are configured in the project.