### PR TITLE
chore: add redirect pages for social links and GitHub

### DIFF
--- a/apps/web/app/(redirects)/discord/page.tsx
+++ b/apps/web/app/(redirects)/discord/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function DiscordPage() {
+  redirect("https://discord.gg/dJNvPEHth6");
+}

--- a/apps/web/app/(redirects)/gh/page.tsx
+++ b/apps/web/app/(redirects)/gh/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function GhPage() {
+  redirect("https://github.com/tambo-ai/tambo");
+}

--- a/apps/web/app/(redirects)/issue/page.tsx
+++ b/apps/web/app/(redirects)/issue/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function IssuePage() {
+  redirect("https://github.com/tambo-ai/tambo/issues/new");
+}

--- a/apps/web/app/(redirects)/x/page.tsx
+++ b/apps/web/app/(redirects)/x/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function XPage() {
+  redirect("https://x.com/tambo_ai");
+}


### PR DESCRIPTION
This PR adds convenient redirect pages for quick access to our social links and GitHub resources:

-  → GitHub issues page for bug reports
-  → GitHub repository  
-  → X (Twitter) account (@tambo_ai)
-  → Discord server

These short links make it easy to share and access our community resources.