### PR TITLE
fix: don't await during chunk handling

### DIFF
--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -1168,7 +1168,7 @@ export class ThreadsService {
           return;
         }
 
-        updateMessage(db, inProgressMessage.id, {
+        await updateMessage(db, inProgressMessage.id, {
           ...threadMessage,
           content: convertContentPartToDto(threadMessage.content),
         });


### PR DESCRIPTION
To avoid 'slow' chunks coming out of the api every 500ms while we await a cancellation check and update the db, fires those requests off without awaiting