### PR TITLE
feat: show complete endpoint for openai-compatible

### DIFF
--- a/apps/web/components/dashboard-components/project-details/provider-key-section.tsx
+++ b/apps/web/components/dashboard-components/project-details/provider-key-section.tsx
@@ -836,7 +836,7 @@ export function ProviderKeySection({
                         </p>
                       )}
                       <p className="text-xs text-foreground">
-                        requests will be sent to{" "}
+                        Requests will be sent to{" "}
                         <span className="inline-flex rounded-md bg-muted px-2 py-0.5 font-mono">
                           {baseUrl.trim()
                             ? baseUrl.trim().replace(/\/$/, "")


### PR DESCRIPTION
Updates Provider section of project settings to make it clear what the full endpoint we will make requests to looks like:

<img width="978" height="193" alt="image" src="https://github.com/user-attachments/assets/9dc33c06-512e-4538-912c-607724ae6c10" />
