### PR TITLE
fix: ignore context key in advance for thread

### DIFF
--- a/apps/api/src/common/utils/extract-context-info.ts
+++ b/apps/api/src/common/utils/extract-context-info.ts
@@ -31,10 +31,7 @@ export function extractContextInfo(
   request: Request,
   apiContextKey: string | undefined,
 ): ContextInfo {
-  const projectId = request[ProjectId];
-  if (!projectId) {
-    throw new BadRequestException("Project ID is required");
-  }
+  const projectId = extractProjectId(request);
 
   const bearerContextKey = request[ContextKey];
 
@@ -52,4 +49,18 @@ export function extractContextInfo(
     projectId,
     contextKey,
   };
+}
+
+/**
+ * Extracts project ID from the request.
+ * @param request - Express request object
+ * @returns Project ID
+ * @throws BadRequestException if project ID is missing
+ */
+export function extractProjectId(request: Request): string {
+  const projectId = request[ProjectId];
+  if (!projectId) {
+    throw new BadRequestException("Project ID is required");
+  }
+  return projectId;
 }

--- a/apps/api/src/threads/__tests__/threads.controller.integration.spec.ts
+++ b/apps/api/src/threads/__tests__/threads.controller.integration.spec.ts
@@ -4,7 +4,10 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { ContentPartType, MessageRole } from "@tambo-ai-cloud/core";
 import request from "supertest";
 import { SentryExceptionFilter } from "../../common/filters/sentry-exception.filter";
-import { extractContextInfo } from "../../common/utils/extract-context-info";
+import {
+  extractContextInfo,
+  extractProjectId,
+} from "../../common/utils/extract-context-info";
 import { ApiKeyGuard } from "../../projects/guards/apikey.guard";
 import { BearerTokenGuard } from "../../projects/guards/bearer-token.guard";
 import { ProjectAccessOwnGuard } from "../../projects/guards/project-access-own.guard";
@@ -20,10 +23,13 @@ jest.mock("../threads.service", () => ({
   })),
 }));
 
-// Mock the extractContextInfo function
+// Mock the extract context info functions
 jest.mock("../../common/utils/extract-context-info");
 const mockExtractContextInfo = extractContextInfo as jest.MockedFunction<
   typeof extractContextInfo
+>;
+const mockExtractProjectId = extractProjectId as jest.MockedFunction<
+  typeof extractProjectId
 >;
 
 describe("ThreadsController - Integration Tests (HTTP Response Format)", () => {
@@ -71,6 +77,8 @@ describe("ThreadsController - Integration Tests (HTTP Response Format)", () => {
 
     // Reset mocks
     jest.clearAllMocks();
+    mockExtractContextInfo.mockClear();
+    mockExtractProjectId.mockClear();
   });
 
   afterEach(async () => {
@@ -78,12 +86,12 @@ describe("ThreadsController - Integration Tests (HTTP Response Format)", () => {
   });
 
   describe("Error Response Format", () => {
-    it("should return default NestJS JSON error format when extractContextInfo throws BadRequestException", async () => {
+    it("should return default NestJS JSON error format when extractProjectId throws BadRequestException", async () => {
       // Arrange
       const testError = new BadRequestException("Project ID is required");
       const requestBody = createValidAdvanceRequestDto();
 
-      mockExtractContextInfo.mockImplementation(() => {
+      mockExtractProjectId.mockImplementation(() => {
         throw testError;
       });
 
@@ -169,14 +177,11 @@ describe("ThreadsController - Integration Tests (HTTP Response Format)", () => {
   });
 
   describe("Successful Response Format", () => {
-    it("should successfully start stream when extractContextInfo works correctly", async () => {
+    it("should successfully start stream when extractProjectId works correctly", async () => {
       // Arrange
       const requestBody = createValidAdvanceRequestDto();
 
-      mockExtractContextInfo.mockReturnValue({
-        projectId: "test-project-id",
-        contextKey: "test-context-key",
-      });
+      mockExtractProjectId.mockReturnValue("test-project-id");
 
       // Mock a successful stream response
       const mockStream = {

--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -969,7 +969,7 @@ export class ThreadsService {
       // Use the shared method to create the TamboBackend instance
       const tamboBackend = await this.createHydraBackendForThread(
         thread.id,
-        `${projectId}-${thread.contextKey ?? TAMBO_ANON_CONTEXT_KEY}`,
+        `${projectId}-${thread.contextKey || TAMBO_ANON_CONTEXT_KEY}`,
       );
 
       // Log available components
@@ -1011,7 +1011,7 @@ export class ThreadsService {
       const mcpAccessToken = await this.authService.generateMcpAccessToken(
         projectId,
         thread.id,
-        thread.contextKey,
+        thread.contextKey || undefined,
       );
 
       if (stream) {

--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -969,7 +969,7 @@ export class ThreadsService {
       // Use the shared method to create the TamboBackend instance
       const tamboBackend = await this.createHydraBackendForThread(
         thread.id,
-        `${projectId}-${contextKey ?? TAMBO_ANON_CONTEXT_KEY}`,
+        `${projectId}-${thread.contextKey ?? TAMBO_ANON_CONTEXT_KEY}`,
       );
 
       // Log available components
@@ -1011,7 +1011,7 @@ export class ThreadsService {
       const mcpAccessToken = await this.authService.generateMcpAccessToken(
         projectId,
         thread.id,
-        contextKey,
+        thread.contextKey,
       );
 
       if (stream) {


### PR DESCRIPTION
When a client fetches a list of threads, the threads include their contextKey field.

When a request was made to threads/:id/advance or threads/:id/advanceStream the client might want to send a userToken, but 'undefined' contextKey. Since a pre-existing thread already has a contextKey, which is included in requests to the API, sending the userToken would cause an error about using only one or the other.

Removes the contextKey extraction logic from the advance/advanceStream routes for a specific threadId since they already have a contextKey.