### PR TITLE
fix(revert): Revert "fix: ignore context key in advance for thread"

### DIFF
--- a/apps/api/src/common/utils/extract-context-info.ts
+++ b/apps/api/src/common/utils/extract-context-info.ts
@@ -31,7 +31,10 @@ export function extractContextInfo(
   request: Request,
   apiContextKey: string | undefined,
 ): ContextInfo {
-  const projectId = extractProjectId(request);
+  const projectId = request[ProjectId];
+  if (!projectId) {
+    throw new BadRequestException("Project ID is required");
+  }
 
   const bearerContextKey = request[ContextKey];
 
@@ -49,18 +52,4 @@ export function extractContextInfo(
     projectId,
     contextKey,
   };
-}
-
-/**
- * Extracts project ID from the request.
- * @param request - Express request object
- * @returns Project ID
- * @throws BadRequestException if project ID is missing
- */
-export function extractProjectId(request: Request): string {
-  const projectId = request[ProjectId];
-  if (!projectId) {
-    throw new BadRequestException("Project ID is required");
-  }
-  return projectId;
 }

--- a/apps/api/src/threads/__tests__/threads.controller.integration.spec.ts
+++ b/apps/api/src/threads/__tests__/threads.controller.integration.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { ContentPartType, MessageRole } from "@tambo-ai-cloud/core";
 import request from "supertest";
 import { SentryExceptionFilter } from "../../common/filters/sentry-exception.filter";
-import {
-  extractContextInfo,
-  extractProjectId,
-} from "../../common/utils/extract-context-info";
+import { extractContextInfo } from "../../common/utils/extract-context-info";
 import { ApiKeyGuard } from "../../projects/guards/apikey.guard";
 import { BearerTokenGuard } from "../../projects/guards/bearer-token.guard";
 import { ProjectAccessOwnGuard } from "../../projects/guards/project-access-own.guard";
@@ -23,13 +20,10 @@ jest.mock("../threads.service", () => ({
   })),
 }));
 
-// Mock the extract context info functions
+// Mock the extractContextInfo function
 jest.mock("../../common/utils/extract-context-info");
 const mockExtractContextInfo = extractContextInfo as jest.MockedFunction<
   typeof extractContextInfo
->;
-const mockExtractProjectId = extractProjectId as jest.MockedFunction<
-  typeof extractProjectId
 >;
 
 describe("ThreadsController - Integration Tests (HTTP Response Format)", () => {
@@ -77,8 +71,6 @@ describe("ThreadsController - Integration Tests (HTTP Response Format)", () => {
 
     // Reset mocks
     jest.clearAllMocks();
-    mockExtractContextInfo.mockClear();
-    mockExtractProjectId.mockClear();
   });
 
   afterEach(async () => {
@@ -86,12 +78,12 @@ describe("ThreadsController - Integration Tests (HTTP Response Format)", () => {
   });
 
   describe("Error Response Format", () => {
-    it("should return default NestJS JSON error format when extractProjectId throws BadRequestException", async () => {
+    it("should return default NestJS JSON error format when extractContextInfo throws BadRequestException", async () => {
       // Arrange
       const testError = new BadRequestException("Project ID is required");
       const requestBody = createValidAdvanceRequestDto();
 
-      mockExtractProjectId.mockImplementation(() => {
+      mockExtractContextInfo.mockImplementation(() => {
         throw testError;
       });
 
@@ -177,11 +169,14 @@ describe("ThreadsController - Integration Tests (HTTP Response Format)", () => {
   });
 
   describe("Successful Response Format", () => {
-    it("should successfully start stream when extractProjectId works correctly", async () => {
+    it("should successfully start stream when extractContextInfo works correctly", async () => {
       // Arrange
       const requestBody = createValidAdvanceRequestDto();
 
-      mockExtractProjectId.mockReturnValue("test-project-id");
+      mockExtractContextInfo.mockReturnValue({
+        projectId: "test-project-id",
+        contextKey: "test-context-key",
+      });
 
       // Mock a successful stream response
       const mockStream = {

--- a/apps/api/src/threads/__tests__/threads.controller.spec.ts
+++ b/apps/api/src/threads/__tests__/threads.controller.spec.ts
@@ -10,10 +10,7 @@ import { BadRequestException } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { ContentPartType, MessageRole } from "@tambo-ai-cloud/core";
 import { Request, Response } from "express";
-import {
-  extractContextInfo,
-  extractProjectId,
-} from "../../common/utils/extract-context-info";
+import { extractContextInfo } from "../../common/utils/extract-context-info";
 import { ApiKeyGuard } from "../../projects/guards/apikey.guard";
 import { BearerTokenGuard } from "../../projects/guards/bearer-token.guard";
 import { ProjectAccessOwnGuard } from "../../projects/guards/project-access-own.guard";
@@ -24,9 +21,6 @@ import { ThreadsService } from "../threads.service";
 
 const mockExtractContextInfo = extractContextInfo as jest.MockedFunction<
   typeof extractContextInfo
->;
-const mockExtractProjectId = extractProjectId as jest.MockedFunction<
-  typeof extractProjectId
 >;
 
 describe("ThreadsController - Stream Routes Error Propagation", () => {
@@ -81,15 +75,15 @@ describe("ThreadsController - Stream Routes Error Propagation", () => {
   });
 
   describe("POST /:id/advancestream", () => {
-    it("should propagate errors from extractProjectId to the caller", async () => {
+    it("should propagate errors from extractContextInfo to the caller", async () => {
       // Arrange
       const threadId = "test-thread-id";
       const advanceRequestDto = createValidAdvanceRequestDto();
       const testError = new BadRequestException(
-        "Any error from extractProjectId",
+        "Any error from extractContextInfo",
       );
 
-      mockExtractProjectId.mockImplementation(() => {
+      mockExtractContextInfo.mockImplementation(() => {
         throw testError;
       });
 
@@ -103,7 +97,7 @@ describe("ThreadsController - Stream Routes Error Propagation", () => {
         ),
       ).rejects.toThrow(testError);
 
-      // The service should not be called when extractProjectId fails
+      // The service should not be called when extractContextInfo fails
       expect(threadsService.advanceThread).not.toHaveBeenCalled();
     });
 
@@ -113,7 +107,10 @@ describe("ThreadsController - Stream Routes Error Propagation", () => {
       const advanceRequestDto = createValidAdvanceRequestDto();
       const internalError = new Error("Internal service error");
 
-      mockExtractProjectId.mockReturnValue("test-project-id");
+      mockExtractContextInfo.mockReturnValue({
+        projectId: "test-project-id",
+        contextKey: "test-context-key",
+      });
 
       jest
         .spyOn(threadsService, "advanceThread")

--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -969,7 +969,7 @@ export class ThreadsService {
       // Use the shared method to create the TamboBackend instance
       const tamboBackend = await this.createHydraBackendForThread(
         thread.id,
-        `${projectId}-${thread.contextKey || TAMBO_ANON_CONTEXT_KEY}`,
+        `${projectId}-${contextKey ?? TAMBO_ANON_CONTEXT_KEY}`,
       );
 
       // Log available components
@@ -1011,7 +1011,7 @@ export class ThreadsService {
       const mcpAccessToken = await this.authService.generateMcpAccessToken(
         projectId,
         thread.id,
-        thread.contextKey || undefined,
+        contextKey,
       );
 
       if (stream) {


### PR DESCRIPTION
Discussed with @MichaelMilstead this is a problem, allows users to bypass contextKey checks

Reverts tambo-ai/tambo-cloud#1570