### PR TITLE
refactor: deprecate actionType for consistency

### DIFF
--- a/apps/api/src/threads/dto/message.dto.ts
+++ b/apps/api/src/threads/dto/message.dto.ts
@@ -82,6 +82,9 @@ export class ThreadMessageDto {
   })
   tool_call_id?: string;
 
+  /**
+   * @deprecated Use the role and the presence of tool calls to determine the action type
+   */
   @IsEnum(ActionType)
   @ApiProperty({
     deprecated: true,
@@ -134,6 +137,9 @@ export class MessageRequest implements InternalThreadMessage {
   @IsOptional()
   toolCallRequest?: ToolCallRequestDto;
 
+  /**
+   * @deprecated Use the role and the presence of tool calls to determine the action type
+   */
   @IsOptional()
   tool_call_id?: string;
   @IsOptional()

--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -1991,7 +1991,7 @@ export class ThreadsService {
     thread: Thread,
   ): Promise<boolean> {
     if (
-      userMessage.actionType === ActionType.ToolResponse &&
+      userMessage.role === MessageRole.Tool &&
       thread.generationStage === GenerationStage.CANCELLED
     ) {
       return true;

--- a/apps/api/src/threads/util/messages.ts
+++ b/apps/api/src/threads/util/messages.ts
@@ -12,7 +12,7 @@ import {
   operations,
   schema,
 } from "@tambo-ai-cloud/db";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { MessageRequest, ThreadMessageDto } from "../dto/message.dto";
 import {
   convertContentDtoToContentPart,
@@ -42,7 +42,7 @@ export async function addMessage(
     additionalContext: messageDto.additionalContext ?? {},
   });
 
-  if (messageDto.actionType === ActionType.ToolResponse && messageDto.error) {
+  if (messageDto.role === MessageRole.Tool && messageDto.error) {
     //Update the previous request message with the error
     //Find message with matching toolCallId and action is tool call
     await propagateErrorToPreviousToolCall(
@@ -91,7 +91,7 @@ export async function updateMessage(
     additionalContext: messageDto.additionalContext ?? {},
   });
 
-  if (messageDto.actionType === ActionType.ToolResponse && messageDto.error) {
+  if (messageDto.role === MessageRole.Tool && messageDto.error) {
     //Update the previous request message with the error
     //Find message with matching toolCallId and action is tool call
     await propagateErrorToPreviousToolCall(
@@ -214,21 +214,4 @@ export function threadMessageDtoToThreadMessage(
       content: convertContentDtoToContentPart(message.content),
     }),
   );
-}
-
-/**
- * Find the previous tool call message with a matching tool call ID
- */
-export async function findPreviousToolCallMessage(
-  db: HydraDb,
-  threadId: string,
-  toolCallId: string,
-): Promise<schema.DBMessage | undefined> {
-  return await db.query.messages.findFirst({
-    where: and(
-      eq(schema.messages.threadId, threadId),
-      eq(schema.messages.toolCallId, toolCallId),
-      eq(schema.messages.actionType, ActionType.ToolCall),
-    ),
-  });
 }

--- a/apps/web/components/observability/messages/thread-messages-modal.tsx
+++ b/apps/web/components/observability/messages/thread-messages-modal.tsx
@@ -88,7 +88,7 @@ function findAllMatches(thread: ThreadType, query: string): SearchMatch[] {
 
   messages.forEach((message) => {
     // Skip tool responses that are handled with their requests
-    if (message.actionType === "tool_response") return;
+    if (message.role === "tool") return;
 
     // Check message content
     if (searchInMessage(message, query)) {
@@ -130,9 +130,7 @@ function findAllMatches(thread: ThreadType, query: string): SearchMatch[] {
 
       // Check tool response
       const toolResponse = messages.find(
-        (msg) =>
-          msg.actionType === "tool_response" &&
-          msg.toolCallId === message.toolCallId,
+        (msg) => msg.role === "tool" && msg.toolCallId === message.toolCallId,
       );
 
       if (toolResponse) {

--- a/apps/web/components/observability/messages/thread-messages.tsx
+++ b/apps/web/components/observability/messages/thread-messages.tsx
@@ -65,7 +65,7 @@ export function ThreadMessages({
     for (let i = 0; i < messages.length; i++) {
       const message = messages[i];
 
-      if (message.actionType === "tool_response") {
+      if (message.role === "tool") {
         continue;
       }
 
@@ -81,7 +81,7 @@ export function ThreadMessages({
         const toolResponse = messages.find(
           (msg, idx) =>
             idx > i &&
-            msg.actionType === "tool_response" &&
+            msg.role === "tool" &&
             msg.toolCallId === message.toolCallId,
         );
 

--- a/apps/web/components/observability/messages/tool-call-message.tsx
+++ b/apps/web/components/observability/messages/tool-call-message.tsx
@@ -47,7 +47,7 @@ export const ToolCallMessage = memo(
     // Check for errors
     const hasToolCallError = message.error;
     const hasToolResponseError =
-      toolResponse?.actionType === "tool_response" && toolResponse?.error;
+      toolResponse?.role === "tool" && toolResponse?.error;
     const hasAnyError = hasToolCallError || hasToolResponseError;
 
     return (

--- a/apps/web/components/ui/tambo/message.tsx
+++ b/apps/web/components/ui/tambo/message.tsx
@@ -115,7 +115,7 @@ const Message = React.forwardRef<HTMLDivElement, MessageProps>(
     );
 
     // Don't render tool response messages as they're shown in tool call dropdowns
-    if (message.actionType === "tool_response") {
+    if (message.role === "tool") {
       return null;
     }
     return (
@@ -288,10 +288,10 @@ const ToolcallInfo = React.forwardRef<HTMLDivElement, ToolcallInfoProps>(
       if (currentMessageIndex === -1) return null;
       for (let i = currentMessageIndex + 1; i < thread.messages.length; i++) {
         const nextMessage = thread.messages[i];
-        if (nextMessage.actionType === "tool_response") {
+        if (nextMessage.role === "tool") {
           return nextMessage;
         }
-        if (nextMessage.actionType === "tool_call") {
+        if (nextMessage.role === "assistant" && nextMessage.toolCallRequest) {
           break;
         }
       }

--- a/apps/web/components/ui/tambo/message.tsx
+++ b/apps/web/components/ui/tambo/message.tsx
@@ -256,8 +256,7 @@ function getToolStatusMessage(
   message: TamboThreadMessage,
   isLoading: boolean | undefined,
 ) {
-  const isToolCall = message.actionType === "tool_call";
-  if (!isToolCall) return null;
+  if (message.role !== "assistant" || !message.toolCallRequest) return null;
 
   const toolCallMessage = isLoading
     ? `Calling ${message.toolCallRequest?.toolName ?? "tool"}`
@@ -298,7 +297,7 @@ const ToolcallInfo = React.forwardRef<HTMLDivElement, ToolcallInfoProps>(
       return null;
     }, [message, thread?.messages]);
 
-    if (message.actionType !== "tool_call") {
+    if (message.role !== "assistant" || !message.toolCallRequest) {
       return null;
     }
 

--- a/packages/core/src/threads.ts
+++ b/packages/core/src/threads.ts
@@ -13,6 +13,7 @@ export enum MessageRole {
   User = "user",
   Assistant = "assistant",
   System = "system",
+  /** A tool call response - generally from the user, often JSON */
   Tool = "tool",
   /**
    * Hydra is a new role that is used to represent a message from the Hydra assistant.
@@ -30,6 +31,7 @@ export type OpenAIRole =
 
 /**
  * Defines the types of actions that can occur in a thread
+ * @deprecated - use the role and the presence of tool calls to determine the action type
  */
 export enum ActionType {
   ToolCall = "tool_call",

--- a/packages/db/src/operations/messages.ts
+++ b/packages/db/src/operations/messages.ts
@@ -1,5 +1,5 @@
-import { ActionType } from "@tambo-ai-cloud/core";
-import { and, eq } from "drizzle-orm";
+import { MessageRole } from "@tambo-ai-cloud/core";
+import { and, eq, isNotNull } from "drizzle-orm";
 import { schema } from "..";
 import { messages, projectMembers } from "../schema";
 import type { HydraDb } from "../types";
@@ -104,7 +104,8 @@ export async function findPreviousToolCallMessage(
     where: and(
       eq(schema.messages.threadId, threadId),
       eq(schema.messages.toolCallId, toolCallId),
-      eq(schema.messages.actionType, ActionType.ToolCall),
+      eq(schema.messages.role, MessageRole.Assistant),
+      isNotNull(schema.messages.toolCallRequest),
     ),
   });
 }

--- a/packages/db/src/operations/thread.ts
+++ b/packages/db/src/operations/thread.ts
@@ -1,4 +1,4 @@
-import { ActionType, GenerationStage } from "@tambo-ai-cloud/core";
+import { ActionType, GenerationStage, MessageRole } from "@tambo-ai-cloud/core";
 import {
   and,
   count,
@@ -6,6 +6,7 @@ import {
   eq,
   ilike,
   inArray,
+  isNotNull,
   isNull,
   or,
   sql,
@@ -254,8 +255,9 @@ export async function getMessages(
       : and(
           eq(schema.messages.threadId, threadId),
           or(
-            isNull(schema.messages.actionType),
-            eq(schema.messages.actionType, ActionType.ToolCall),
+            isNull(schema.messages.role),
+            eq(schema.messages.role, MessageRole.Assistant),
+            isNotNull(schema.messages.toolCallRequest),
           ),
         ),
     orderBy: (messages, { asc }) => [asc(messages.createdAt)],


### PR DESCRIPTION
we had a mix of code checking actionType to see if there are tool calls/etc - we should be using the role + presence of a toolCallRequest

I checked the prod database, the only messages where actionType didn't match the role/toolCallRequest stuff was messages back in feburary where we were still flushing out the data model

- **switch from actionType to role**
- **add jsdoc for deprecation**
- **deprecate tool_call action type**
- **update everything else to use roles + tool calls instead of action type**
