### PR TITLE
Set tambo assistant components to open in editing state

### DIFF
--- a/apps/web/components/dashboard-components/project-details/custom-instructions-editor.tsx
+++ b/apps/web/components/dashboard-components/project-details/custom-instructions-editor.tsx
@@ -40,13 +40,16 @@ export const CustomInstructionsEditorProps = z.object({
 interface CustomInstructionsEditorProps {
   project?: { id: string; name: string; customInstructions?: string | null };
   onEdited?: () => void;
+  /** If true, starts in editing mode (used in chat context) */
+  startEditing?: boolean;
 }
 
 export function CustomInstructionsEditor({
   project,
   onEdited,
+  startEditing,
 }: CustomInstructionsEditorProps) {
-  const [isEditing, setIsEditing] = useState(true);
+  const [isEditing, setIsEditing] = useState(!!startEditing);
   const [customInstructions, setCustomInstructions] = useState(
     project?.customInstructions || "",
   );

--- a/apps/web/components/dashboard-components/project-details/custom-instructions-editor.tsx
+++ b/apps/web/components/dashboard-components/project-details/custom-instructions-editor.tsx
@@ -46,7 +46,7 @@ export function CustomInstructionsEditor({
   project,
   onEdited,
 }: CustomInstructionsEditorProps) {
-  const [isEditing, setIsEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState(true);
   const [customInstructions, setCustomInstructions] = useState(
     project?.customInstructions || "",
   );

--- a/apps/web/components/dashboard-components/project-details/custom-instructions-editor.tsx
+++ b/apps/web/components/dashboard-components/project-details/custom-instructions-editor.tsx
@@ -23,7 +23,8 @@ export const CustomInstructionsEditorSchema = z.object({
     .describe("Custom instructions for the AI assistant."),
 });
 
-export const CustomInstructionsEditorProps = z.object({
+// Base props schema used for LLM-driven rendering (excludes UI-only controls)
+export const CustomInstructionsEditorLLMPropsSchema = z.object({
   project: CustomInstructionsEditorSchema.optional().describe(
     "The project to edit custom instructions for.",
   ),
@@ -37,19 +38,25 @@ export const CustomInstructionsEditorProps = z.object({
     ),
 });
 
+// Extended component props schema for UI-only props (not passed to LLM)
+export const CustomInstructionsEditorComponentPropsSchema =
+  CustomInstructionsEditorLLMPropsSchema.extend({
+    editMode: z.boolean().optional().describe("When true, start in edit mode."),
+  });
+
 interface CustomInstructionsEditorProps {
   project?: { id: string; name: string; customInstructions?: string | null };
   onEdited?: () => void;
   /** If true, starts in editing mode (used in chat context) */
-  startEditing?: boolean;
+  editMode?: boolean;
 }
 
 export function CustomInstructionsEditor({
   project,
   onEdited,
-  startEditing,
+  editMode,
 }: CustomInstructionsEditorProps) {
-  const [isEditing, setIsEditing] = useState(!!startEditing);
+  const [isEditing, setIsEditing] = useState(!!editMode);
   const [customInstructions, setCustomInstructions] = useState(
     project?.customInstructions || "",
   );

--- a/apps/web/components/dashboard-components/project-details/tool-call-limit-editor.tsx
+++ b/apps/web/components/dashboard-components/project-details/tool-call-limit-editor.tsx
@@ -48,7 +48,7 @@ export function ToolCallLimitEditor({
   onEdited,
 }: ToolCallLimitEditorProps) {
   const { toast } = useToast();
-  const [isEditing, setIsEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState(true);
   const [maxToolCallLimit, setMaxToolCallLimit] = useState("");
 
   const { mutateAsync: updateProject, isPending: isUpdating } =

--- a/apps/web/components/dashboard-components/project-details/tool-call-limit-editor.tsx
+++ b/apps/web/components/dashboard-components/project-details/tool-call-limit-editor.tsx
@@ -16,7 +16,8 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 
-export const ToolCallLimitEditorPropsSchema = z.object({
+// Base props schema used by LLM (excludes UI-only props)
+export const ToolCallLimitEditorLLMPropsSchema = z.object({
   project: z
     .object({
       id: z.string().describe("The unique identifier for the project."),
@@ -35,6 +36,12 @@ export const ToolCallLimitEditorPropsSchema = z.object({
     ),
 });
 
+// Extended component props schema for UI-only props (not passed to LLM)
+export const ToolCallLimitEditorPropsSchema =
+  ToolCallLimitEditorLLMPropsSchema.extend({
+    editMode: z.boolean().optional().describe("When true, start in edit mode."),
+  });
+
 interface ToolCallLimitEditorProps {
   project: {
     id: string;
@@ -42,16 +49,16 @@ interface ToolCallLimitEditorProps {
   };
   onEdited?: () => void;
   /** If true, starts in editing mode (used in chat context) */
-  startEditing?: boolean;
+  editMode?: boolean;
 }
 
 export function ToolCallLimitEditor({
   project,
   onEdited,
-  startEditing,
+  editMode,
 }: ToolCallLimitEditorProps) {
   const { toast } = useToast();
-  const [isEditing, setIsEditing] = useState(!!startEditing);
+  const [isEditing, setIsEditing] = useState(!!editMode);
   const [maxToolCallLimit, setMaxToolCallLimit] = useState("");
 
   const { mutateAsync: updateProject, isPending: isUpdating } =

--- a/apps/web/components/dashboard-components/project-details/tool-call-limit-editor.tsx
+++ b/apps/web/components/dashboard-components/project-details/tool-call-limit-editor.tsx
@@ -41,14 +41,17 @@ interface ToolCallLimitEditorProps {
     maxToolCallLimit: number;
   };
   onEdited?: () => void;
+  /** If true, starts in editing mode (used in chat context) */
+  startEditing?: boolean;
 }
 
 export function ToolCallLimitEditor({
   project,
   onEdited,
+  startEditing,
 }: ToolCallLimitEditorProps) {
   const { toast } = useToast();
-  const [isEditing, setIsEditing] = useState(true);
+  const [isEditing, setIsEditing] = useState(!!startEditing);
   const [maxToolCallLimit, setMaxToolCallLimit] = useState("");
 
   const { mutateAsync: updateProject, isPending: isUpdating } =

--- a/apps/web/components/ui/tambo/chatwithtambo/config.ts
+++ b/apps/web/components/ui/tambo/chatwithtambo/config.ts
@@ -41,7 +41,29 @@ import {
   ThreadTableContainer,
   ThreadTableContainerSchema,
 } from "@/components/observability/thread-table/thread-table-container";
+import React from "react";
 import { z } from "zod";
+
+// Wrappers to start in edit mode only when rendered via chat context
+const ChatCustomInstructionsEditor = (
+  props: z.infer<typeof CustomInstructionsEditorProps>,
+) =>
+  React.createElement(CustomInstructionsEditor as any, {
+    ...props,
+    startEditing: true,
+  });
+
+const ChatToolCallLimitEditor = (
+  props: z.infer<typeof ToolCallLimitEditorPropsSchema>,
+) =>
+  // ToolCallLimitEditorPropsSchema describes the shape; cast to any to forward as props
+  // since zod schema type is not exactly the React props type
+  // Consumers (chat) will pass the correct props per schema
+   
+  React.createElement(ToolCallLimitEditor as any, {
+    ...(props as any),
+    startEditing: true,
+  });
 
 export const tamboRegisteredComponents = [
   {
@@ -76,7 +98,7 @@ export const tamboRegisteredComponents = [
     name: "CustomInstructionsEditor",
     description:
       "Allows users to create and edit custom instructions that are automatically included in every AI conversation for their project. Features inline editing with save/cancel functionality, preview mode, and handles empty states. Use when users want to set project-wide AI behavior guidelines, context, or specific instructions that should apply to all interactions.",
-    component: CustomInstructionsEditor,
+    component: ChatCustomInstructionsEditor,
     propsSchema: CustomInstructionsEditorProps,
   },
   {
@@ -118,7 +140,7 @@ export const tamboRegisteredComponents = [
     name: "ToolCallLimitEditor",
     description:
       "Manages the maximum number of tool calls allowed per AI response to prevent infinite loops and control resource usage. Features inline editing with save/cancel functionality, input validation, and animated state transitions. Shows current limit prominently with explanatory text about behavior when limits are reached. Use when users need to configure or modify their project's tool call limits for performance and cost control.",
-    component: ToolCallLimitEditor,
+    component: ChatToolCallLimitEditor,
     propsSchema: ToolCallLimitEditorPropsSchema,
   },
 ];

--- a/apps/web/components/ui/tambo/chatwithtambo/config.ts
+++ b/apps/web/components/ui/tambo/chatwithtambo/config.ts
@@ -11,7 +11,7 @@ import {
 } from "@/components/dashboard-components/project-details/available-mcp-servers";
 import {
   CustomInstructionsEditor,
-  CustomInstructionsEditorProps,
+  CustomInstructionsEditorLLMPropsSchema,
 } from "@/components/dashboard-components/project-details/custom-instructions-editor";
 import {
   DailyMessagesChart,
@@ -31,7 +31,7 @@ import {
 } from "@/components/dashboard-components/project-details/provider-key-section";
 import {
   ToolCallLimitEditor,
-  ToolCallLimitEditorPropsSchema,
+  ToolCallLimitEditorLLMPropsSchema,
 } from "@/components/dashboard-components/project-details/tool-call-limit-editor";
 import {
   ProjectTable,
@@ -46,23 +46,23 @@ import { z } from "zod";
 
 // Wrappers to start in edit mode only when rendered via chat context
 const ChatCustomInstructionsEditor = (
-  props: z.infer<typeof CustomInstructionsEditorProps>,
+  props: z.infer<typeof CustomInstructionsEditorLLMPropsSchema>,
 ) =>
   React.createElement(CustomInstructionsEditor as any, {
     ...props,
-    startEditing: true,
+    editMode: true,
   });
 
 const ChatToolCallLimitEditor = (
-  props: z.infer<typeof ToolCallLimitEditorPropsSchema>,
+  props: z.infer<typeof ToolCallLimitEditorLLMPropsSchema>,
 ) =>
   // ToolCallLimitEditorPropsSchema describes the shape; cast to any to forward as props
   // since zod schema type is not exactly the React props type
   // Consumers (chat) will pass the correct props per schema
-   
+
   React.createElement(ToolCallLimitEditor as any, {
     ...(props as any),
-    startEditing: true,
+    editMode: true,
   });
 
 export const tamboRegisteredComponents = [
@@ -99,7 +99,7 @@ export const tamboRegisteredComponents = [
     description:
       "Allows users to create and edit custom instructions that are automatically included in every AI conversation for their project. Features inline editing with save/cancel functionality, preview mode, and handles empty states. Use when users want to set project-wide AI behavior guidelines, context, or specific instructions that should apply to all interactions.",
     component: ChatCustomInstructionsEditor,
-    propsSchema: CustomInstructionsEditorProps,
+    propsSchema: CustomInstructionsEditorLLMPropsSchema,
   },
   {
     name: "AvailableMcpServers",
@@ -141,6 +141,6 @@ export const tamboRegisteredComponents = [
     description:
       "Manages the maximum number of tool calls allowed per AI response to prevent infinite loops and control resource usage. Features inline editing with save/cancel functionality, input validation, and animated state transitions. Shows current limit prominently with explanatory text about behavior when limits are reached. Use when users need to configure or modify their project's tool call limits for performance and cost control.",
     component: ChatToolCallLimitEditor,
-    propsSchema: ToolCallLimitEditorPropsSchema,
+    propsSchema: ToolCallLimitEditorLLMPropsSchema,
   },
 ];


### PR DESCRIPTION
Set `CustomInstructionsEditor` and `ToolCallLimitEditor` to open in editing mode by default to allow immediate modification of assistant settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad27106b-5c83-4ce9-a3b2-e7049b5de0f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad27106b-5c83-4ce9-a3b2-e7049b5de0f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

