### PR TITLE
feat(web): update custom LLM parameters with example support and fix reasoning parameters to go under provider options

### DIFF
--- a/apps/web/components/dashboard-components/project-details/custom-llm-parameters/editor-modes.tsx
+++ b/apps/web/components/dashboard-components/project-details/custom-llm-parameters/editor-modes.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { CardDescription } from "@/components/ui/card";
-import { LlmParameterUIType } from "@tambo-ai-cloud/core";
+import { JSONValue, LlmParameterUIType } from "@tambo-ai-cloud/core";
 import { AnimatePresence, motion } from "framer-motion";
 import { Plus } from "lucide-react";
 import type { FC } from "react";
@@ -127,6 +127,7 @@ interface EditModeProps {
   onApplySuggestion: (suggestion: {
     key: string;
     type: LlmParameterUIType;
+    example?: JSONValue;
   }) => void;
   onSave: () => void;
   onCancel: () => void;

--- a/apps/web/components/dashboard-components/project-details/custom-llm-parameters/editor.tsx
+++ b/apps/web/components/dashboard-components/project-details/custom-llm-parameters/editor.tsx
@@ -2,7 +2,11 @@
 
 import { useToast } from "@/hooks/use-toast";
 import { api, RouterOutputs } from "@/trpc/react";
-import { LlmParameterUIType, llmProviderConfig } from "@tambo-ai-cloud/core";
+import {
+  JSONValue,
+  LlmParameterUIType,
+  llmProviderConfig,
+} from "@tambo-ai-cloud/core";
 import { AnimatePresence } from "framer-motion";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { EditMode, ViewMode } from "./editor-modes";
@@ -183,7 +187,7 @@ export function CustomLlmParametersEditor({
       {
         id: generateParameterId("new"),
         key: "",
-        value: "",
+        value: getDefaultValueForType("string"),
         type: "string" as const,
       },
     ];
@@ -192,7 +196,11 @@ export function CustomLlmParametersEditor({
   }, [parameters, allowCustomParameters, toast]);
 
   const handleApplySuggestion = useCallback(
-    (suggestion: { key: string; type: LlmParameterUIType }) => {
+    (suggestion: {
+      key: string;
+      type: LlmParameterUIType;
+      example?: JSONValue;
+    }) => {
       if (parameters.some((p) => p.key === suggestion.key)) {
         toast({
           variant: "default",
@@ -207,8 +215,9 @@ export function CustomLlmParametersEditor({
         {
           id: generateParameterId(suggestion.key),
           key: suggestion.key,
-          value: getDefaultValueForType(suggestion.type),
+          value: getDefaultValueForType(suggestion.type, suggestion.example),
           type: suggestion.type,
+          example: suggestion.example,
         },
       ];
       setParameters(newParams);
@@ -236,6 +245,7 @@ export function CustomLlmParametersEditor({
         key,
         description: value.description,
         type: value.uiType,
+        example: value.example,
       }),
     );
     const seen = new Set<string>();

--- a/apps/web/components/dashboard-components/project-details/custom-llm-parameters/parameter-row.tsx
+++ b/apps/web/components/dashboard-components/project-details/custom-llm-parameters/parameter-row.tsx
@@ -165,9 +165,7 @@ export function ParameterRow({
           </Select>
         ) : shouldUseTextarea(local.type) ? (
           <Textarea
-            placeholder={
-              local.type === "array" ? '[1, "two", 3]' : '{"key": "value"}'
-            }
+            placeholder={JSON.stringify(local.example)}
             value={local.value}
             onChange={(e) => handleValueChange(e.target.value)}
             className={`flex-1 resize-y min-h-[80px] font-mono text-sm ${
@@ -177,7 +175,7 @@ export function ParameterRow({
           />
         ) : (
           <Input
-            placeholder={local.type === "number" ? "0" : "Value"}
+            placeholder={JSON.stringify(local.example)}
             value={local.value}
             onChange={(e) => handleValueChange(e.target.value)}
             className={`flex-1 ${validationError ? "border-red-500" : ""}`}

--- a/apps/web/components/dashboard-components/project-details/custom-llm-parameters/types.ts
+++ b/apps/web/components/dashboard-components/project-details/custom-llm-parameters/types.ts
@@ -1,4 +1,8 @@
-import { LlmParameterUIType, PARAMETER_METADATA } from "@tambo-ai-cloud/core";
+import {
+  JSONValue,
+  LlmParameterUIType,
+  PARAMETER_METADATA,
+} from "@tambo-ai-cloud/core";
 /**
  * Represents a single parameter entry in the UI.
  * All values are stored as strings for form inputs, then converted based on type.
@@ -8,12 +12,14 @@ export interface ParameterEntry {
   key: string;
   value: string; // Always string for input fields
   type: LlmParameterUIType;
+  example?: JSONValue;
 }
 
 export const PARAMETER_SUGGESTIONS = Object.entries(PARAMETER_METADATA).map(
-  ([key, { description, uiType }]) => ({
+  ([key, { description, uiType, example }]) => ({
     key,
     description,
     type: uiType,
+    example,
   }),
 );

--- a/apps/web/components/dashboard-components/project-details/custom-llm-parameters/utils.ts
+++ b/apps/web/components/dashboard-components/project-details/custom-llm-parameters/utils.ts
@@ -1,4 +1,8 @@
-import { CustomLlmParameters, LlmParameterUIType } from "@tambo-ai-cloud/core";
+import {
+  CustomLlmParameters,
+  JSONValue,
+  LlmParameterUIType,
+} from "@tambo-ai-cloud/core";
 import { ParameterEntry } from "./types";
 
 /**
@@ -147,21 +151,30 @@ export const shouldUseTextarea = (type: LlmParameterUIType) => {
 };
 
 /**
- * Gets the default value for a given parameter type
+ * Gets the default value for a given parameter type, preferring examples when available
  */
-export const getDefaultValueForType = (type: LlmParameterUIType): string => {
+export const getDefaultValueForType = (
+  type: LlmParameterUIType,
+  example?: JSONValue,
+): string => {
+  // Use example if provided
+  if (example !== undefined) {
+    return valueToString(example);
+  }
+
+  // Fallback to meaningful examples
   switch (type) {
     case "boolean":
-      return "false";
+      return "true";
     case "number":
-      return "0";
+      return "0.7";
     case "array":
-      return "[]";
+      return '["example", "values"]';
     case "object":
-      return "{}";
+      return '{"key": "value"}';
     case "string":
     default:
-      return "";
+      return "example";
   }
 };
 

--- a/packages/backend/src/services/llm/ai-sdk-client.ts
+++ b/packages/backend/src/services/llm/ai-sdk-client.ts
@@ -299,8 +299,6 @@ export class AISdkClient implements LLMClient {
       ...filteredCustomParams, // Custom parameters override all, but exclude model-specific provider params
     };
 
-    console.log("baseConfig", baseConfig);
-
     if (params.stream) {
       // added explicit await even though types say it isn't necessary
       const result = await streamText(baseConfig);

--- a/packages/core/src/llm-config-types.ts
+++ b/packages/core/src/llm-config-types.ts
@@ -25,6 +25,7 @@ export type LlmParameterUIType =
 export interface LlmParameterSchema {
   description: string;
   uiType: LlmParameterUIType;
+  example?: JSONValue;
 }
 
 /** A mapping of parameter names to their schema */
@@ -39,22 +40,49 @@ export const PARAMETER_METADATA: LlmParameterMetadata<
   temperature: {
     description: "Controls randomness in output",
     uiType: "number",
+    example: 0.5,
   },
   maxOutputTokens: {
     description: "Maximum tokens to generate",
     uiType: "number",
+    example: 1000,
   },
-  maxRetries: { description: "Maximum number of retries", uiType: "number" },
-  topP: { description: "Nucleus sampling threshold", uiType: "number" },
-  topK: { description: "Top K sampling", uiType: "number" },
-  presencePenalty: { description: "Penalty for new topics", uiType: "number" },
-  frequencyPenalty: { description: "Penalty for repetition", uiType: "number" },
+  maxRetries: {
+    description: "Maximum number of retries",
+    uiType: "number",
+    example: 3,
+  },
+  topP: {
+    description: "Nucleus sampling threshold",
+    uiType: "number",
+    example: 0.5,
+  },
+  topK: { description: "Top K sampling", uiType: "number", example: 50 },
+  presencePenalty: {
+    description: "Penalty for new topics",
+    uiType: "number",
+    example: 0.1,
+  },
+  frequencyPenalty: {
+    description: "Penalty for repetition",
+    uiType: "number",
+    example: 0.1,
+  },
   stopSequences: {
     description: "Sequences where generation stops",
     uiType: "array",
+    example: ["\n"],
   },
-  seed: { description: "Deterministic sampling seed", uiType: "number" },
-  headers: { description: "Custom headers for requests", uiType: "object" },
+  seed: {
+    description: "Deterministic sampling seed",
+    uiType: "number",
+    example: 42,
+  },
+  headers: {
+    description: "Custom headers for requests",
+    uiType: "object",
+    example: { Authorization: "Bearer <your-api-key>" },
+  },
 };
 
 export interface LlmModelConfigInfo {

--- a/packages/core/src/llms/llm.config.ts
+++ b/packages/core/src/llms/llm.config.ts
@@ -40,6 +40,9 @@ export const llmProviderConfig: LlmProviderConfig = {
     docLinkRoot: "https://docs.mistral.ai/",
     apiKeyLink: "https://console.mistral.ai/api-keys",
     models: mistralModels,
+    providerSpecificParams: {
+      parallelToolCalls: false,
+    },
   },
   "openai-compatible": {
     apiName: "openai-compatible",

--- a/packages/core/src/llms/models/gemini.ts
+++ b/packages/core/src/llms/models/gemini.ts
@@ -1,4 +1,16 @@
-import type { LlmModelConfig } from "../../llm-config-types";
+import type {
+  LlmModelConfig,
+  LlmParameterMetadata,
+} from "../../llm-config-types";
+
+const reasoningParameters: LlmParameterMetadata = {
+  thinkingConfig: {
+    description:
+      "Set the thinkingBudget and includeThoughts in a JSON object, thinkingBudget is the number of tokens you want to spend on thinking and includeThoughts is a boolean to include thoughts in the response.",
+    uiType: "object",
+    example: { thinkingBudget: 8192, includeThoughts: true },
+  },
+};
 
 export const geminiModels: LlmModelConfig = {
   "gemini-2.5-pro": {
@@ -11,6 +23,7 @@ export const geminiModels: LlmModelConfig = {
       "https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro",
     tamboDocLink: "https://docs.tambo.co",
     inputTokenLimit: 1048576,
+    modelSpecificParams: reasoningParameters,
   },
   "gemini-2.5-flash": {
     apiName: "gemini-2.5-flash",
@@ -22,6 +35,7 @@ export const geminiModels: LlmModelConfig = {
       "https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash",
     tamboDocLink: "https://docs.tambo.co",
     inputTokenLimit: 1048576,
+    modelSpecificParams: reasoningParameters,
   },
   "gemini-2.0-flash": {
     apiName: "gemini-2.0-flash",

--- a/packages/core/src/llms/models/openai.ts
+++ b/packages/core/src/llms/models/openai.ts
@@ -8,10 +8,12 @@ const reasoningParameters: LlmParameterMetadata = {
     description:
       "Controls the effort of the model to reason, only if reasoningSummary is also set",
     uiType: "string",
+    example: "medium",
   },
   reasoningSummary: {
     description: "Enables reasoning token output",
     uiType: "string",
+    example: "auto",
   },
 };
 export const openaiModels: LlmModelConfig = {


### PR DESCRIPTION
- make it so that the `modelSpecificParams` go under provider options instead of with base config
- add reasoning for gemini models
	- reasoning for `anthropic` can not be enabled as we force tool call usage, so that and reasoning can not be used together
- updated custom llm parameters so that default values are now automatically added based on the examples