### PR TITLE
chore: fix settings component alignment and text overflow

### DIFF
--- a/apps/web/components/dashboard-components/project-details/agent-settings.tsx
+++ b/apps/web/components/dashboard-components/project-details/agent-settings.tsx
@@ -38,7 +38,7 @@ export function AgentSettings({
       animate={{ opacity: 1, height: "auto" }}
       exit={{ opacity: 0, height: 0 }}
       transition={{ duration: 0.3, ease: "easeInOut" }}
-      className="space-y-4 rounded-md max-w-xl"
+      className="space-y-4 rounded-md w-full"
     >
       <div className="space-y-2">
         <Label htmlFor="agent-provider">Agent Provider</Label>

--- a/apps/web/components/dashboard-components/project-details/custom-instructions-editor.tsx
+++ b/apps/web/components/dashboard-components/project-details/custom-instructions-editor.tsx
@@ -195,7 +195,7 @@ export function CustomInstructionsEditor({
                 transition={{ duration: 0.3, ease: "easeInOut" }}
                 className="space-y-3"
               >
-                <CardDescription className="text-sm text-foreground max-w-sm mb-4">
+                <CardDescription className="text-sm text-foreground mb-4">
                   These instructions are added to each conversation to guide
                   tambo&apos;s responses.
                 </CardDescription>
@@ -252,7 +252,7 @@ export function CustomInstructionsEditor({
                     {project.customInstructions}
                   </motion.div>
                 ) : (
-                  <CardDescription className="text-sm text-foreground max-w-sm">
+                  <CardDescription className="text-sm text-foreground">
                     These instructions are added to each conversation to guide
                     tambo&apos;s responses.
                   </CardDescription>

--- a/apps/web/components/dashboard-components/project-details/custom-llm-parameters/editor-modes.tsx
+++ b/apps/web/components/dashboard-components/project-details/custom-llm-parameters/editor-modes.tsx
@@ -94,7 +94,7 @@ export function ViewMode({ parameters, onEdit, isLoading }: ViewModeProps) {
       className="flex items-start justify-between gap-4"
     >
       <div className="flex-1 flex flex-col gap-3">
-        <CardDescription className="text-sm text-foreground max-w-sm">
+        <CardDescription className="text-sm text-foreground">
           Custom parameters sent with each LLM request.
         </CardDescription>
 
@@ -158,7 +158,7 @@ export function EditMode({
       transition={{ duration: 0.3, ease: "easeInOut" }}
       className="flex flex-col"
     >
-      <CardDescription className="text-sm text-foreground max-w-md mb-4">
+      <CardDescription className="text-sm text-foreground mb-4">
         {allowCustomParameters
           ? "Add custom parameters to send with each LLM request."
           : "Add parameters from the suggestions below. Custom parameters are only available for OpenAI-compatible providers."}

--- a/apps/web/components/dashboard-components/project-details/dashboard-graph.tsx
+++ b/apps/web/components/dashboard-components/project-details/dashboard-graph.tsx
@@ -198,9 +198,7 @@ export const DashboardGraph = React.forwardRef<
               <p className="font-medium">{emptyState.title}</p>
             )}
             {emptyState.description && (
-              <p className="text-sm text-center max-w-xs">
-                {emptyState.description}
-              </p>
+              <p className="text-sm text-center">{emptyState.description}</p>
             )}
           </div>
         </div>

--- a/apps/web/components/dashboard-components/project-details/mcp-server-editor.tsx
+++ b/apps/web/components/dashboard-components/project-details/mcp-server-editor.tsx
@@ -178,7 +178,7 @@ export function McpServerEditor({
     projectId &&
     redirectToAuth;
   return (
-    <div className="flex flex-col gap-2 rounded-md max-w-xl">
+    <div className="flex flex-col gap-2 rounded-md w-full">
       <div className="flex flex-col gap-1">
         <label htmlFor={urlInputId} className="block text-sm font-medium">
           Server URL

--- a/apps/web/components/dashboard-components/project-details/oauth-settings.tsx
+++ b/apps/web/components/dashboard-components/project-details/oauth-settings.tsx
@@ -221,7 +221,7 @@ export function OAuthSettings({ project }: OAuthSettingsProps) {
         <CardTitle className="flex items-center gap-2 text-lg font-semibold">
           OAuth Token Validation
         </CardTitle>
-        <p className="text-sm font-sans text-foreground max-w-md">
+        <p className="text-sm font-sans text-foreground">
           Configure how OAuth bearer tokens are validated for your
           project&apos;s API endpoints.
         </p>
@@ -241,7 +241,7 @@ export function OAuthSettings({ project }: OAuthSettingsProps) {
         </div>
         {/* Validation Mode Selection */}
         <div className="space-y-4">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between w-full">
             <Label className="text-base font-medium">Validation Mode</Label>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/apps/web/components/dashboard-components/project-details/provider-key-section.tsx
+++ b/apps/web/components/dashboard-components/project-details/provider-key-section.tsx
@@ -749,7 +749,7 @@ export function ProviderKeySection({
       {/* usage chip moved below mode toggle */}
       <CardContent className="space-y-4 p-6">
         {/* Mode Toggle */}
-        <div className="max-w-xl">
+        <div className="w-full">
           <Label className="mb-2 block">AI Mode</Label>
           <RadioGroup
             value={mode}
@@ -784,13 +784,13 @@ export function ProviderKeySection({
         </div>
 
         {mode === AiProviderType.LLM && (
-          <div className="max-w-xl">
-            <p className="text-sm font-sans text-foreground max-w-sm">
+          <div className="w-full">
+            <p className="text-sm font-sans text-foreground">
               Get started with 500 starter LLM calls. Tambo is BYO Model — add
               your provider key anytime to continue.
             </p>
             <div className="flex items-center gap-2 mt-2 mb-2">
-              <p className="text-xs font-sans text-success max-w-xs bg-success-background rounded-full p-2">
+              <p className="text-xs font-sans text-success bg-success-background rounded-full p-2">
                 {projectMessageUsage?.messageCount} of 500 starter LLM calls
                 used
               </p>
@@ -799,7 +799,7 @@ export function ProviderKeySection({
         )}
 
         {/* Provider • Model Select (LLM Mode) */}
-        <div className="space-y-2 max-w-xl">
+        <div className="space-y-2 w-full">
           <AnimatePresence initial={false} mode="wait">
             {mode === AiProviderType.LLM && (
               <motion.div
@@ -855,7 +855,7 @@ export function ProviderKeySection({
                     animate={{ opacity: 1, height: "auto" }}
                     exit={{ opacity: 0, height: 0 }}
                     transition={{ duration: 0.3, ease: "easeInOut" }}
-                    className="space-y-4 rounded-md max-w-xl"
+                    className="space-y-4 rounded-md w-full"
                   >
                     {/* Model Information */}
                     {currentSelectedOption.model?.notes && (

--- a/apps/web/components/dashboard-components/project-details/tool-call-limit-editor.tsx
+++ b/apps/web/components/dashboard-components/project-details/tool-call-limit-editor.tsx
@@ -121,7 +121,7 @@ export function ToolCallLimitEditor({
     <Card>
       <CardHeader>
         <CardTitle className="text-lg font-semibold">Tool Call Limit</CardTitle>
-        <CardDescription className="text-sm font-sans text-foreground max-w-md">
+        <CardDescription className="text-sm font-sans text-foreground">
           Set the maximum number of tool calls allowed per response. This helps
           prevent infinite loops and controls resource usage.
         </CardDescription>


### PR DESCRIPTION
Remove `max-width` constraints and apply `w-full` to settings components to fix text clipping and ensure consistent right-edge alignment.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f029717-b5fc-49a0-8e4d-44ea0a3d3cfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f029717-b5fc-49a0-8e4d-44ea0a3d3cfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

