### PR TITLE
test(agent-client): Fix tests to actually generate messages

### DIFF
--- a/packages/backend/src/services/llm/__snapshots__/agent-client.test.ts.snap
+++ b/packages/backend/src/services/llm/__snapshots__/agent-client.test.ts.snap
@@ -117,7 +117,7 @@ exports[`AgentClient Event Processing Complex Conversation Flow should handle a 
     "complete": true,
     "message": {
       "content": "Conversation completed",
-      "id": "message-csjtoe8b6xr",
+      "id": "message-1",
       "role": "assistant",
     },
     "type": "message",
@@ -130,10 +130,47 @@ exports[`AgentClient Event Processing Edge Cases should handle empty tool calls 
   {
     "message": {
       "content": "",
-      "id": "tambo-assistant-complete",
+      "id": "msg-1",
+      "role": "assistant",
+      "toolCalls": [
+        {
+          "function": {
+            "arguments": "",
+            "name": "test_tool",
+          },
+          "id": "call-1",
+          "type": "function",
+        },
+      ],
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "msg-1",
+      "role": "assistant",
+      "toolCalls": [
+        {
+          "function": {
+            "arguments": "{"param": "value"}",
+            "name": "test_tool",
+          },
+          "id": "call-1",
+          "type": "function",
+        },
+      ],
+    },
+    "type": "message",
+  },
+  {
+    "complete": true,
+    "message": {
+      "content": "Empty tool calls completed",
+      "id": "message-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;
@@ -141,12 +178,13 @@ exports[`AgentClient Event Processing Edge Cases should handle empty tool calls 
 exports[`AgentClient Event Processing Edge Cases should handle run finished with object result 1`] = `
 [
   {
+    "complete": true,
     "message": {
-      "content": "",
-      "id": "tambo-assistant-complete",
+      "content": "{"status":"success","data":{"key":"value"}}",
+      "id": "message-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;
@@ -154,12 +192,13 @@ exports[`AgentClient Event Processing Edge Cases should handle run finished with
 exports[`AgentClient Event Processing Edge Cases should handle run finished with string result 1`] = `
 [
   {
+    "complete": true,
     "message": {
-      "content": "",
-      "id": "tambo-assistant-complete",
+      "content": "Simple string result",
+      "id": "message-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;
@@ -169,10 +208,47 @@ exports[`AgentClient Event Processing Edge Cases should handle tool calls with n
   {
     "message": {
       "content": "",
-      "id": "tambo-assistant-complete",
+      "id": "msg-1",
+      "role": "assistant",
+      "toolCalls": [
+        {
+          "function": {
+            "arguments": "",
+            "name": "test_tool",
+          },
+          "id": "call-1",
+          "type": "function",
+        },
+      ],
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "msg-1",
+      "role": "assistant",
+      "toolCalls": [
+        {
+          "function": {
+            "arguments": "{"type": "unexpected"}",
+            "name": "test_tool",
+          },
+          "id": "call-1",
+          "type": "function",
+        },
+      ],
+    },
+    "type": "message",
+  },
+  {
+    "complete": true,
+    "message": {
+      "content": "Non-function tool calls completed",
+      "id": "message-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;
@@ -181,11 +257,20 @@ exports[`AgentClient Event Processing Messages Snapshot Events should handle mes
 [
   {
     "message": {
-      "content": "",
-      "id": "tambo-assistant-complete",
+      "content": "Hello! How can I help you?",
+      "id": "msg-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
+  },
+  {
+    "complete": true,
+    "message": {
+      "content": "Messages snapshot completed",
+      "id": "message-1",
+      "role": "assistant",
+    },
+    "type": "message",
   },
 ]
 `;
@@ -194,11 +279,21 @@ exports[`AgentClient Event Processing Messages Snapshot Events should handle mes
 [
   {
     "message": {
-      "content": "",
-      "id": "tambo-assistant-complete",
+      "content": "Tool result",
+      "id": "tool-msg-1",
+      "role": "tool",
+      "toolCallId": "call-1",
+    },
+    "type": "message",
+  },
+  {
+    "complete": true,
+    "message": {
+      "content": "Tool messages snapshot completed",
+      "id": "message-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;
@@ -207,11 +302,20 @@ exports[`AgentClient Event Processing Messages Snapshot Events should handle mes
 [
   {
     "message": {
-      "content": "",
-      "id": "tambo-assistant-complete",
+      "content": "Hello, world!",
+      "id": "user-msg-1",
+      "role": "user",
+    },
+    "type": "message",
+  },
+  {
+    "complete": true,
+    "message": {
+      "content": "User messages snapshot completed",
+      "id": "message-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;
@@ -219,12 +323,13 @@ exports[`AgentClient Event Processing Messages Snapshot Events should handle mes
 exports[`AgentClient Event Processing Run Events should handle run error 1`] = `
 [
   {
+    "complete": true,
     "message": {
-      "content": "",
-      "id": "tambo-assistant-complete",
+      "content": "Run error completed",
+      "id": "message-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;
@@ -232,12 +337,13 @@ exports[`AgentClient Event Processing Run Events should handle run error 1`] = `
 exports[`AgentClient Event Processing Run Events should handle run started/finished sequence 1`] = `
 [
   {
+    "complete": true,
     "message": {
-      "content": "",
-      "id": "tambo-assistant-complete",
+      "content": "Task completed successfully",
+      "id": "message-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;
@@ -245,12 +351,13 @@ exports[`AgentClient Event Processing Run Events should handle run started/finis
 exports[`AgentClient Event Processing State Events should handle state delta 1`] = `
 [
   {
+    "complete": true,
     "message": {
-      "content": "",
-      "id": "tambo-assistant-complete",
+      "content": "State delta completed",
+      "id": "message-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;
@@ -258,12 +365,13 @@ exports[`AgentClient Event Processing State Events should handle state delta 1`]
 exports[`AgentClient Event Processing State Events should handle state snapshot 1`] = `
 [
   {
+    "complete": true,
     "message": {
-      "content": "",
-      "id": "tambo-assistant-complete",
+      "content": "State snapshot completed",
+      "id": "message-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;
@@ -271,12 +379,13 @@ exports[`AgentClient Event Processing State Events should handle state snapshot 
 exports[`AgentClient Event Processing Step Events should handle step started/finished sequence 1`] = `
 [
   {
+    "complete": true,
     "message": {
-      "content": "",
-      "id": "tambo-assistant-complete",
+      "content": "Step sequence completed",
+      "id": "message-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;
@@ -286,10 +395,35 @@ exports[`AgentClient Event Processing Text Message Events should handle text mes
   {
     "message": {
       "content": "",
-      "id": "tambo-assistant-complete",
+      "id": "msg-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "Chunk 1",
+      "id": "msg-1",
+      "role": "assistant",
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "Chunk 1 Chunk 2",
+      "id": "msg-1",
+      "role": "assistant",
+    },
+    "type": "message",
+  },
+  {
+    "complete": true,
+    "message": {
+      "content": "Message completed",
+      "id": "message-1",
+      "role": "assistant",
+    },
+    "type": "message",
   },
 ]
 `;
@@ -324,7 +458,7 @@ exports[`AgentClient Event Processing Text Message Events should handle text mes
     "complete": true,
     "message": {
       "content": "Message completed",
-      "id": "message-959z4uw34ju",
+      "id": "message-1",
       "role": "assistant",
     },
     "type": "message",
@@ -337,10 +471,66 @@ exports[`AgentClient Event Processing Thinking Events should handle multiple thi
   {
     "message": {
       "content": "",
-      "id": "tambo-assistant-complete",
+      "id": "message-1",
+      "reasoning": [],
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "message-1",
+      "reasoning": [
+        "",
+      ],
+      "role": "assistant",
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "message-1",
+      "reasoning": [
+        "Step 1: Analyze the problem",
+      ],
+      "role": "assistant",
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "message-1",
+      "reasoning": [
+        "Step 1: Analyze the problem",
+        "",
+      ],
+      "role": "assistant",
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "message-1",
+      "reasoning": [
+        "Step 1: Analyze the problem",
+        "Step 2: Consider solutions",
+      ],
+      "role": "assistant",
+    },
+    "type": "message",
+  },
+  {
+    "complete": true,
+    "message": {
+      "content": "Multiple thinking completed",
+      "id": "message-2",
+      "role": "assistant",
+    },
+    "type": "message",
   },
 ]
 `;
@@ -350,10 +540,53 @@ exports[`AgentClient Event Processing Thinking Events should handle thinking sta
   {
     "message": {
       "content": "",
-      "id": "tambo-assistant-complete",
+      "id": "message-1",
+      "reasoning": [],
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "message-1",
+      "reasoning": [
+        "",
+      ],
+      "role": "assistant",
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "message-1",
+      "reasoning": [
+        "Let me think about this...",
+      ],
+      "role": "assistant",
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "message-1",
+      "reasoning": [
+        "Let me think about this... I need to consider multiple factors.",
+      ],
+      "role": "assistant",
+    },
+    "type": "message",
+  },
+  {
+    "complete": true,
+    "message": {
+      "content": "Thinking completed",
+      "id": "message-2",
+      "role": "assistant",
+    },
+    "type": "message",
   },
 ]
 `;
@@ -363,10 +596,65 @@ exports[`AgentClient Event Processing Tool Call Events should handle tool call c
   {
     "message": {
       "content": "",
-      "id": "tambo-assistant-complete",
+      "id": "msg-1",
+      "role": "assistant",
+      "toolCalls": [
+        {
+          "function": {
+            "arguments": "",
+            "name": "test_tool",
+          },
+          "id": "call-1",
+          "type": "function",
+        },
+      ],
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "msg-1",
+      "role": "assistant",
+      "toolCalls": [
+        {
+          "function": {
+            "arguments": "{"param": "value",
+            "name": "test_tool",
+          },
+          "id": "call-1",
+          "type": "function",
+        },
+      ],
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "msg-1",
+      "role": "assistant",
+      "toolCalls": [
+        {
+          "function": {
+            "arguments": "{"param": "value"}",
+            "name": "test_tool",
+          },
+          "id": "call-1",
+          "type": "function",
+        },
+      ],
+    },
+    "type": "message",
+  },
+  {
+    "complete": true,
+    "message": {
+      "content": "Tool call completed",
+      "id": "message-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;
@@ -375,11 +663,21 @@ exports[`AgentClient Event Processing Tool Call Events should handle tool call r
 [
   {
     "message": {
-      "content": "",
-      "id": "tambo-assistant-complete",
+      "content": "Tool execution result",
+      "id": "tool-msg-1",
+      "role": "tool",
+      "toolCallId": "call-1",
+    },
+    "type": "message",
+  },
+  {
+    "complete": true,
+    "message": {
+      "content": "Tool result completed",
+      "id": "message-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;
@@ -389,10 +687,65 @@ exports[`AgentClient Event Processing Tool Call Events should handle tool call s
   {
     "message": {
       "content": "",
-      "id": "tambo-assistant-complete",
+      "id": "msg-1",
+      "role": "assistant",
+      "toolCalls": [
+        {
+          "function": {
+            "arguments": "",
+            "name": "test_tool",
+          },
+          "id": "call-1",
+          "type": "function",
+        },
+      ],
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "msg-1",
+      "role": "assistant",
+      "toolCalls": [
+        {
+          "function": {
+            "arguments": "{"param": "value"}",
+            "name": "test_tool",
+          },
+          "id": "call-1",
+          "type": "function",
+        },
+      ],
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "msg-1",
+      "role": "assistant",
+      "toolCalls": [
+        {
+          "function": {
+            "arguments": "{"param": "value"}",
+            "name": "test_tool",
+          },
+          "id": "call-1",
+          "type": "function",
+        },
+      ],
+    },
+    "type": "message",
+  },
+  {
+    "complete": true,
+    "message": {
+      "content": "Tool call completed",
+      "id": "message-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;

--- a/packages/backend/src/services/llm/__snapshots__/agent-client.test.ts.snap
+++ b/packages/backend/src/services/llm/__snapshots__/agent-client.test.ts.snap
@@ -5,10 +5,122 @@ exports[`AgentClient Event Processing Complex Conversation Flow should handle a 
   {
     "message": {
       "content": "",
-      "id": "tambo-assistant-complete",
+      "id": "assistant-msg-1",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "I can help you with that! Let me check the weather for you.",
+      "id": "assistant-msg-1",
+      "role": "assistant",
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "I can help you with that! Let me check the weather for you.",
+      "id": "assistant-msg-1",
+      "role": "assistant",
+      "toolCalls": [
+        {
+          "function": {
+            "arguments": "",
+            "name": "get_weather",
+          },
+          "id": "call-weather-1",
+          "type": "function",
+        },
+      ],
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "I can help you with that! Let me check the weather for you.",
+      "id": "assistant-msg-1",
+      "role": "assistant",
+      "toolCalls": [
+        {
+          "function": {
+            "arguments": "{"location": "New York"}",
+            "name": "get_weather",
+          },
+          "id": "call-weather-1",
+          "type": "function",
+        },
+      ],
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "I can help you with that! Let me check the weather for you.",
+      "id": "assistant-msg-1",
+      "role": "assistant",
+      "toolCalls": [
+        {
+          "function": {
+            "arguments": "{"location": "New York"}",
+            "name": "get_weather",
+          },
+          "id": "call-weather-1",
+          "type": "function",
+        },
+      ],
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "{"temperature": 72, "condition": "sunny"}",
+      "id": "tool-msg-1",
+      "role": "tool",
+      "toolCallId": "call-weather-1",
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "user-msg-1",
+      "role": "user",
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "Thanks! What about tomorrow?",
+      "id": "user-msg-1",
+      "role": "user",
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "",
+      "id": "assistant-msg-2",
+      "role": "assistant",
+    },
+    "type": "message",
+  },
+  {
+    "message": {
+      "content": "Tomorrow will be partly cloudy with a high of 75°F.",
+      "id": "assistant-msg-2",
+      "role": "assistant",
+    },
+    "type": "message",
+  },
+  {
+    "complete": true,
+    "message": {
+      "content": "Conversation completed",
+      "id": "message-csjtoe8b6xr",
+      "role": "assistant",
+    },
+    "type": "message",
   },
 ]
 `;
@@ -209,12 +321,13 @@ exports[`AgentClient Event Processing Text Message Events should handle text mes
     "type": "message",
   },
   {
+    "complete": true,
     "message": {
-      "content": "",
-      "id": "tambo-assistant-complete",
+      "content": "Message completed",
+      "id": "message-959z4uw34ju",
       "role": "assistant",
     },
-    "type": "complete",
+    "type": "message",
   },
 ]
 `;

--- a/packages/backend/src/services/llm/agent-client.test.ts
+++ b/packages/backend/src/services/llm/agent-client.test.ts
@@ -1,12 +1,18 @@
 import { BaseEvent, EventType } from "@ag-ui/core";
-import { AgentProviderType } from "@tambo-ai-cloud/core";
-import OpenAI from "openai";
-import { AgentClient, AgentResponse } from "./agent-client";
-
 // Mock the async-adapters module
 jest.mock("./async-adapters", () => ({
   runStreamingAgent: jest.fn(),
 }));
+
+// Mock the message ID generator to return deterministic, monotonically increasing IDs
+let messageIdCounter = 0;
+jest.mock("./message-id-generator", () => ({
+  generateMessageId: jest.fn(() => `message-${++messageIdCounter}`),
+}));
+
+import { AgentProviderType } from "@tambo-ai-cloud/core";
+import OpenAI from "openai";
+import { AgentClient, AgentResponse } from "./agent-client";
 
 import { RunAgentResult } from "@ag-ui/client";
 import { EventHandlerParams, runStreamingAgent } from "./async-adapters";
@@ -19,6 +25,7 @@ describe("AgentClient", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    messageIdCounter = 0; // Reset counter for each test
 
     // Mock the runStreamingAgent to return our mock generator
     mockRunStreamingAgent.mockReturnValue({
@@ -498,12 +505,17 @@ describe("AgentClient", () => {
           delta: " Chunk 2",
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "Message completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -543,12 +555,17 @@ describe("AgentClient", () => {
           toolCallId: "call-1",
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "Tool call completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -587,12 +604,17 @@ describe("AgentClient", () => {
           delta: '"}',
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "Tool call completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -619,12 +641,17 @@ describe("AgentClient", () => {
           content: "Tool execution result",
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "Tool result completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -663,12 +690,17 @@ describe("AgentClient", () => {
           type: EventType.THINKING_END,
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "Thinking completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -715,12 +747,17 @@ describe("AgentClient", () => {
           type: EventType.THINKING_END,
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "Multiple thinking completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -742,12 +779,12 @@ describe("AgentClient", () => {
           result: "Task completed successfully",
         });
 
-        mockGenerator.finish();
-
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -763,12 +800,17 @@ describe("AgentClient", () => {
           error: "Something went wrong",
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "Run error completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -789,12 +831,17 @@ describe("AgentClient", () => {
           type: EventType.STEP_FINISHED,
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "Step sequence completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -812,12 +859,17 @@ describe("AgentClient", () => {
           state: { key: "value" },
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "State snapshot completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -833,12 +885,17 @@ describe("AgentClient", () => {
           delta: { newKey: "newValue" },
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "State delta completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -862,12 +919,17 @@ describe("AgentClient", () => {
           ],
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "Messages snapshot completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -890,12 +952,17 @@ describe("AgentClient", () => {
           ],
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "Tool messages snapshot completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -917,12 +984,17 @@ describe("AgentClient", () => {
           ],
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "User messages snapshot completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -1283,12 +1355,17 @@ describe("AgentClient", () => {
           delta: '{"param": "value"}',
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "Empty tool calls completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -1313,12 +1390,17 @@ describe("AgentClient", () => {
           delta: '{"type": "unexpected"}',
         });
 
-        mockGenerator.finish();
+        mockGenerator.pushEvent({
+          type: EventType.RUN_FINISHED,
+          result: "Non-function tool calls completed",
+        });
 
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -1334,12 +1416,12 @@ describe("AgentClient", () => {
           result: "Simple string result",
         });
 
-        mockGenerator.finish();
-
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });
@@ -1355,12 +1437,12 @@ describe("AgentClient", () => {
           result: { status: "success", data: { key: "value" } },
         });
 
-        mockGenerator.finish();
-
         const responses: AgentResponse[] = [];
         for await (const response of stream) {
           responses.push(response);
         }
+
+        mockGenerator.finish();
 
         expect(responses).toMatchSnapshot();
       });

--- a/packages/backend/src/services/llm/agent-client.ts
+++ b/packages/backend/src/services/llm/agent-client.ts
@@ -29,6 +29,7 @@ import {
 import OpenAI from "openai";
 import { runStreamingAgent } from "./async-adapters";
 import { CompleteParams, LLMResponse } from "./llm-client";
+import { generateMessageId } from "./message-id-generator";
 
 export enum AgentResponseType {
   MESSAGE = "message",
@@ -524,9 +525,6 @@ export class AgentClient {
     }
     throw new Error("Method not implemented.");
   }
-}
-function generateMessageId() {
-  return `message-${Math.random().toString(36).substring(2, 15)}`;
 }
 
 function invalidEvent(eventType: never) {

--- a/packages/backend/src/services/llm/agent-client.ts
+++ b/packages/backend/src/services/llm/agent-client.ts
@@ -387,10 +387,10 @@ export class AgentClient {
           break;
         }
         case EventType.TOOL_CALL_RESULT: {
+          const e = event as ToolCallResultEvent;
           currentToolCalls = currentToolCalls.filter(
             (t) => t.id !== e.toolCallId,
           );
-          const e = event as ToolCallResultEvent;
           const messageId = e.messageId;
           currentMessage = {
             ...createNewMessage(MessageRole.Tool, messageId),

--- a/packages/backend/src/services/llm/message-id-generator.ts
+++ b/packages/backend/src/services/llm/message-id-generator.ts
@@ -1,0 +1,3 @@
+export function generateMessageId(): string {
+  return `message-${Math.random().toString(36).substring(2, 15)}`;
+}


### PR DESCRIPTION
I looked at the snapshots and realized most tests weren't actually generating what they were supposed to, because we were synchronously finishing the generator before we started streaming

- **make the "complete conversation" test pass**
- **make sure tests are actually generating messages**
