### PR TITLE
fix(web): close mobile navigation drawer on hash link clicks

### DIFF
--- a/apps/web/components/mobile-drawer.tsx
+++ b/apps/web/components/mobile-drawer.tsx
@@ -7,6 +7,7 @@ import {
   DrawerHeader,
   DrawerTitle,
   DrawerTrigger,
+  DrawerClose,
 } from "@/components/ui/drawer";
 import { siteConfig } from "@/lib/config";
 import { cn } from "@/lib/utils";
@@ -56,24 +57,28 @@ export function MobileDrawer({
               Dashboard
             </Link>
           )}
-          <Link
-            href="/#pricing"
-            className={cn(
-              buttonVariants({ variant: "ghost" }),
-              "justify-start text-base w-full",
-            )}
-          >
-            Pricing
-          </Link>
-          <Link
-            href="/#mcp"
-            className={cn(
-              buttonVariants({ variant: "ghost" }),
-              "justify-start text-base w-full",
-            )}
-          >
-            MCP
-          </Link>
+          <DrawerClose asChild>
+            <Link
+              href="/#pricing"
+              className={cn(
+                buttonVariants({ variant: "ghost" }),
+                "justify-start text-base w-full",
+              )}
+            >
+              Pricing
+            </Link>
+          </DrawerClose>
+          <DrawerClose asChild>
+            <Link
+              href="/#mcp"
+              className={cn(
+                buttonVariants({ variant: "ghost" }),
+                "justify-start text-base w-full",
+              )}
+            >
+              MCP
+            </Link>
+          </DrawerClose>
           <Link
             href="/blog"
             className={cn(


### PR DESCRIPTION
## Problem

The mobile navigation drawer did not close when users clicked on in-page navigation links (Pricing and MCP). This created a confusing user experience where:

- Clicking "Pricing" scrolled to the section but left the drawer open
- Clicking "MCP" scrolled to the section but left the drawer open  
- Users had to manually close the drawer by clicking outside or on the overlay

**Root cause:** Hash fragment links (/#pricing, /#mcp) don't trigger full page navigation events, so the drawer library's auto-close behavior wasn't activated.
## Video (before)


https://github.com/user-attachments/assets/4c0dd3e8-ed00-4a16-9930-aba554dfc42e



## Solution

Wrapped hash fragment navigation links with DrawerClose component to explicitly close the drawer on click, while preserving the scroll-to-section behavior.

**Changes made to fix the mobile drawer issue:**

* Added DrawerClose import from @/components/ui/drawer
* Wrapped /#pricing Link component with DrawerClose using asChild prop to merge close functionality
* Wrapped /#mcp Link component with DrawerClose using asChild prop to merge close functionality
* Left other links (/dashboard, /blog, external docs) unchanged as they trigger full navigation naturally

## Video (after chnages)

https://github.com/user-attachments/assets/9077eb46-b05a-4d2c-b332-91359d3b0c91

