### PR TITLE
fix(ci): prevent docker images from pushing to docker.io

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -70,10 +70,10 @@ jobs:
           context: .
           file: ./apps/web/Dockerfile
           push: ${{ steps.should_push.outputs.should_push }}
+          load: ${{ steps.should_push.outputs.should_push == 'false' }}
           tags: |
-            tambo-web:latest
-            ghcr.io/tambo-ai/tambo-web-server:${{ github.sha }}
-            ${{ github.ref == 'refs/heads/main' && 'ghcr.io/tambo-ai/tambo-web-server:latest' || '' }}
+            ${{ steps.should_push.outputs.should_push == 'true' && format('ghcr.io/tambo-ai/tambo-web-server:{0}', github.sha) || 'tambo-web:latest' }}
+            ${{ steps.should_push.outputs.should_push == 'true' && github.ref == 'refs/heads/main' && 'ghcr.io/tambo-ai/tambo-web-server:latest' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -85,10 +85,10 @@ jobs:
           context: .
           file: ./apps/api/Dockerfile
           push: ${{ steps.should_push.outputs.should_push }}
+          load: ${{ steps.should_push.outputs.should_push == 'false' }}
           tags: |
-            tambo-api:latest
-            ghcr.io/tambo-ai/tambo-api-server:${{ github.sha }}
-            ${{ github.ref == 'refs/heads/main' && 'ghcr.io/tambo-ai/tambo-api-server:latest' || '' }}
+            ${{ steps.should_push.outputs.should_push == 'true' && format('ghcr.io/tambo-ai/tambo-api-server:{0}', github.sha) || 'tambo-api:latest' }}
+            ${{ steps.should_push.outputs.should_push == 'true' && github.ref == 'refs/heads/main' && 'ghcr.io/tambo-ai/tambo-api-server:latest' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -94,6 +94,14 @@ jobs:
           build-args: |
             NODE_ENV=production
 
+      - name: Ensure local tags for stack
+        if: steps.should_push.outputs.should_push == 'true'
+        run: |
+          docker pull ghcr.io/tambo-ai/tambo-web-server:${{ github.sha }}
+          docker tag ghcr.io/tambo-ai/tambo-web-server:${{ github.sha }} tambo-web:latest
+          docker pull ghcr.io/tambo-ai/tambo-api-server:${{ github.sha }}
+          docker tag ghcr.io/tambo-ai/tambo-api-server:${{ github.sha }} tambo-api:latest
+
       - name: Start Docker stack
         run: |
           ./scripts/tambo-start.sh


### PR DESCRIPTION
Removed unqualified image tags (tambo-web:latest, tambo-api:latest) from push operations to prevent attempts to push to Docker Hub. Now only pushes to ghcr.io when on main branch, and loads images locally for testing on PRs.

- Use conditional tags based on should_push flag
- Add load parameter for local testing scenarios  
- Pull and retag images for local stack use after GHCR push
- Fixes 401 Unauthorized error when pushing images