### PR TITLE
chore(ci): push images to GHCR with release tags during releases

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -9,13 +9,9 @@ on:
     branches:
       - main
       - develop
+  release:
+    types: [published]
   workflow_dispatch:
-  workflow_call:
-    inputs:
-      release_tag:
-        description: "Release tag to use for Docker images (e.g., repo-v0.110.0)"
-        required: false
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -56,11 +52,11 @@ jobs:
       - name: Determine if we should push to GHCR
         id: should_push
         run: |
-          # Push to GHCR when called from release-please with a release tag
-          if [[ -n "${{ inputs.release_tag }}" ]]; then
+          # Push to GHCR only when a release is published
+          if [[ "${{ github.event_name }}" == "release" ]]; then
             echo "should_push=true" >> $GITHUB_OUTPUT
-            echo "release_tag=${{ inputs.release_tag }}" >> $GITHUB_OUTPUT
-            echo "Pushing to GHCR with release tag: ${{ inputs.release_tag }}"
+            echo "release_tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+            echo "Pushing to GHCR with release tag: ${{ github.event.release.tag_name }}"
           else
             echo "should_push=false" >> $GITHUB_OUTPUT
             echo "release_tag=" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -93,17 +92,3 @@ jobs:
           sentry-cli releases new "$VERSION"
           sentry-cli releases set-commits "$VERSION" --auto
           sentry-cli releases finalize "$VERSION"
-
-  build-and-push-docker:
-    name: Build and Push Docker Images
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    uses: ./.github/workflows/docker-test.yml
-    secrets: inherit
-    permissions:
-      contents: read
-      actions: read
-      checks: write
-      packages: write
-    with:
-      release_tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
- Add workflow_call trigger to docker-test workflow with release_tag input
- Modify docker-test to only push to GHCR when explicitly called with a release tag
- Update image tags to use release version (repo-v*.*.*) instead of git SHA
- Add build-and-push-docker job to release-please workflow
- Images now pushed only when release-please PR is merged to main
- PRs and regular pushes build and test locally without pushing to GHCR

This ensures Docker images are versioned with proper release tags and only published during actual releases, providing better control and traceability.