### PR TITLE
feat(alecf): Implement initial POC for sampling

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -54,6 +54,7 @@
     "jose": "^5.10.0",
     "json-schema": "^0.4.0",
     "jsonwebtoken": "^9.0.2",
+    "mime-types": "^2.1.35",
     "openai": "^6.1.0",
     "react-fast-compare": "^3.2.2",
     "reflect-metadata": "^0.2.0",

--- a/apps/api/src/common/__tests__/systemTools.test.ts
+++ b/apps/api/src/common/__tests__/systemTools.test.ts
@@ -60,20 +60,20 @@ describe("getSystemTools", () => {
     // mockDb.query.toolProviders.findMany.mockResolvedValue([]);
     const mockDb = getDb("");
 
-    const tools = await getSystemTools(mockDb, "project123", "thread123", {
-      llmClient: {
-        complete: jest.fn<any>().mockResolvedValue({
-          message: {
-            role: "assistant",
-            content: "This is a sample test response! It should be very long.",
-          },
-        }),
-        chainId: "chain123",
-      },
-    } as any);
+    const mcpHandlers = {
+      elicitation: jest.fn<any>(),
+      sampling: jest.fn<any>(),
+    };
+    const tools = await getSystemTools(
+      mockDb,
+      "project123",
+      "thread123",
+      mcpHandlers,
+    );
     expect(tools).toEqual({
       mcpToolSources: {},
       mcpToolsSchema: [],
+      mcpHandlers,
     });
   });
 

--- a/apps/api/src/common/__tests__/systemTools.test.ts
+++ b/apps/api/src/common/__tests__/systemTools.test.ts
@@ -60,7 +60,17 @@ describe("getSystemTools", () => {
     // mockDb.query.toolProviders.findMany.mockResolvedValue([]);
     const mockDb = getDb("");
 
-    const tools = await getSystemTools(mockDb, "project123", "thread123");
+    const tools = await getSystemTools(mockDb, "project123", "thread123", {
+      llmClient: {
+        complete: jest.fn<any>().mockResolvedValue({
+          message: {
+            role: "assistant",
+            content: "This is a sample test response! It should be very long.",
+          },
+        }),
+        chainId: "chain123",
+      },
+    } as any);
     expect(tools).toEqual({
       mcpToolSources: {},
       mcpToolsSchema: [],
@@ -113,7 +123,17 @@ describe("getSystemTools", () => {
     );
     const mockDb = getDb("");
 
-    const tools = await getSystemTools(mockDb, "project123", "thread123");
+    const tools = await getSystemTools(mockDb, "project123", "thread123", {
+      llmClient: {
+        complete: jest.fn<any>().mockResolvedValue({
+          message: {
+            role: "assistant",
+            content: "This is a sample test response! It should be very long.",
+          },
+        }),
+        chainId: "chain123",
+      },
+    } as any);
     expect(tools).toEqual(
       expect.objectContaining({
         mcpToolSources: {

--- a/apps/api/src/common/systemTools.ts
+++ b/apps/api/src/common/systemTools.ts
@@ -116,6 +116,7 @@ async function getMcpTools(
                 }),
               ),
             });
+            console.log("Got sampling response", response.message);
             return {
               role: response.message.role,
               content: { type: "text", text: response.message.content ?? "" },

--- a/apps/api/src/common/systemTools.ts
+++ b/apps/api/src/common/systemTools.ts
@@ -93,6 +93,19 @@ async function getMcpTools(
         customHeaders,
         authProvider,
         mcpSessionInfo?.sessionId ?? undefined,
+        {
+          async sampling(e) {
+            console.log("Got sampling request", e.method, e.params.messages[0]);
+            return {
+              role: "assistant",
+              content: {
+                text: "This is a sample test response! It should be very long.",
+                type: "text",
+              },
+              model: "foobar",
+            };
+          },
+        },
       );
       if (
         mcpClient.sessionId &&

--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -1063,7 +1063,8 @@ export class ThreadsService {
       const systemToolsStart = Date.now();
 
       const systemTools =
-        cachedSystemTools ?? (await getSystemTools(db, projectId, thread.id));
+        cachedSystemTools ??
+        (await getSystemTools(db, projectId, thread.id, tamboBackend));
       const systemToolsEnd = Date.now();
       const systemToolsDuration = systemToolsEnd - systemToolsStart;
       if (!cachedSystemTools) {

--- a/apps/api/src/threads/util/__tests__/tool.spec.ts
+++ b/apps/api/src/threads/util/__tests__/tool.spec.ts
@@ -91,7 +91,11 @@ describe("tool utilities", () => {
         } as unknown as MCPClient,
       },
       mcpToolsSchema: [],
-    } as McpToolRegistry;
+      mcpHandlers: {
+        elicitation: jest.fn(),
+        sampling: jest.fn(),
+      },
+    };
 
     const toolCallRequest = {
       toolName: "testTool",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "jose": "^5.10.0",
         "json-schema": "^0.4.0",
         "jsonwebtoken": "^9.0.2",
+        "mime-types": "^2.1.35",
         "openai": "^6.1.0",
         "react-fast-compare": "^3.2.2",
         "reflect-metadata": "^0.2.0",

--- a/packages/backend/src/services/llm/llm-client.ts
+++ b/packages/backend/src/services/llm/llm-client.ts
@@ -63,8 +63,6 @@ export interface LLMClient {
     params: StreamingCompleteParams,
   ): Promise<AsyncIterableIterator<Partial<LLMResponse>>>;
   complete(params: CompleteParams): Promise<LLMResponse>;
-
-  complete(params: CompleteParams): Promise<LLMResponse>;
 }
 
 type LLMChatCompletionChoice = Omit<

--- a/packages/backend/src/services/llm/llm-client.ts
+++ b/packages/backend/src/services/llm/llm-client.ts
@@ -62,6 +62,7 @@ export interface LLMClient {
   complete(
     params: StreamingCompleteParams,
   ): Promise<AsyncIterableIterator<Partial<LLMResponse>>>;
+  complete(params: CompleteParams): Promise<LLMResponse>;
 
   complete(params: CompleteParams): Promise<LLMResponse>;
 }

--- a/packages/backend/src/systemTools.ts
+++ b/packages/backend/src/systemTools.ts
@@ -1,4 +1,4 @@
-import { MCPClient } from "@tambo-ai-cloud/core";
+import { MCPClient, MCPHandlers } from "@tambo-ai-cloud/core";
 import OpenAI from "openai";
 
 /** Registry of available MCP tools during a request */
@@ -7,6 +7,8 @@ export interface McpToolRegistry {
   mcpToolsSchema: OpenAI.Chat.Completions.ChatCompletionTool[];
   /** A mapping of MCP tool name to MCP client */
   mcpToolSources: Record<string, MCPClient>;
+
+  mcpHandlers: MCPHandlers;
 }
 
 /** Registry of all browser-side client tools */

--- a/packages/backend/src/tambo-backend.ts
+++ b/packages/backend/src/tambo-backend.ts
@@ -1,10 +1,10 @@
 import {
   AgentProviderType,
   AiProviderType,
+  CustomLlmParameters,
   DEFAULT_OPENAI_MODEL,
   LegacyComponentDecision,
   ThreadMessage,
-  CustomLlmParameters,
 } from "@tambo-ai-cloud/core";
 import OpenAI from "openai";
 import { AvailableComponent } from "./model/component-metadata";
@@ -67,6 +67,7 @@ export interface TamboBackend {
   generateThreadName: (messages: ThreadMessage[]) => Promise<string>;
 
   readonly modelOptions: ModelOptions;
+  readonly llmClient: LLMClient;
 }
 export async function createTamboBackend(
   apiKey: string | undefined,
@@ -78,7 +79,7 @@ export async function createTamboBackend(
 }
 
 class AgenticTamboBackend implements TamboBackend {
-  private llmClient: LLMClient;
+  llmClient: LLMClient;
   /** The current model options for the TamboBackend, filled in with defaults */
   public readonly modelOptions: ModelOptions;
   private agentClient?: AgentClient;
@@ -135,7 +136,7 @@ class AgenticTamboBackend implements TamboBackend {
       case AiProviderType.AGENT: {
         // Normalize and validate required fields for the Agent provider.
         // Trim whitespace from the URL to avoid accepting whitespace-only values.
-        const normalizedAgentUrl: string = (agentUrl ?? "").trim();
+        const normalizedAgentUrl: string = agentUrl?.trim() ?? "";
         if (!agentType || !normalizedAgentUrl) {
           console.error(
             `Got agent type ${agentType} and agentUrl ${normalizedAgentUrl}`,

--- a/packages/core/src/mcp-client.ts
+++ b/packages/core/src/mcp-client.ts
@@ -35,7 +35,7 @@ export enum MCPTransport {
  * });
  * ```
  */
-interface MCPHandlers {
+export interface MCPHandlers {
   elicitation: (e: ElicitRequest) => Promise<ElicitResult>;
   sampling: (e: CreateMessageRequest) => Promise<CreateMessageResult>;
 }

--- a/packages/core/src/mcp-client.ts
+++ b/packages/core/src/mcp-client.ts
@@ -36,8 +36,8 @@ export enum MCPTransport {
  * ```
  */
 interface MCPHandlers {
-  elicitation?: (e: ElicitRequest) => Promise<ElicitResult>;
-  sampling?: (e: CreateMessageRequest) => Promise<CreateMessageResult>;
+  elicitation: (e: ElicitRequest) => Promise<ElicitResult>;
+  sampling: (e: CreateMessageRequest) => Promise<CreateMessageResult>;
 }
 
 /**
@@ -58,7 +58,7 @@ export class MCPClient {
   private endpoint: string;
   private headers: Record<string, string>;
   private authProvider?: OAuthClientProvider;
-  private handlers: MCPHandlers;
+  private handlers: Partial<MCPHandlers>;
   /**
    * Tracks an in-flight reconnect so concurrent triggers coalesce
    * (single-flight). When set, additional calls to `reconnect()` or
@@ -108,7 +108,7 @@ export class MCPClient {
     headers?: Record<string, string>,
     authProvider?: OAuthClientProvider,
     sessionId?: string,
-    handlers: MCPHandlers = {},
+    handlers: Partial<MCPHandlers> = {},
   ) {
     this.endpoint = endpoint;
     this.headers = headers ?? {};
@@ -138,7 +138,7 @@ export class MCPClient {
     headers: Record<string, string> | undefined,
     authProvider: OAuthClientProvider | undefined,
     sessionId: string | undefined,
-    handlers: MCPHandlers = {},
+    handlers: Partial<MCPHandlers> = {},
   ): Promise<MCPClient> {
     const mcpClient = new MCPClient(
       endpoint,
@@ -313,9 +313,8 @@ export class MCPClient {
    * @returns The initialized MCP client
    */
   private initializeClient() {
-    const elicitationCapability = this.handlers.elicitation
-      ? { elicitation: {} }
-      : {};
+    const elicitationCapability =
+      (this.handlers.elicitation ?? false) ? { elicitation: {} } : {};
     const samplingCapability = this.handlers.sampling ? { sampling: {} } : {};
     const client = new Client(
       {


### PR DESCRIPTION
This does not yet record the sampling messages in the thread (waiting on #1893) - but a sampling round trip will work

- **stub out the sampling**
- **jam tamboBackend through mcp stuff to make sampling work**
- **update tests**
- **console logs**
- **distinguish between required and partial**
- **move abstraction out to MCPHandlers**
- **add mime-types so we can map mp3 <-> mime types**
- **add yet another inline message converter**
- **better handling for unknown type**
