### PR TITLE
feat(sampling): Add child messages when sampling call comes through

### DIFF
--- a/apps/api/src/threads/threads.controller.ts
+++ b/apps/api/src/threads/threads.controller.ts
@@ -224,7 +224,7 @@ export class ThreadsController {
     @Param("id") threadId: string,
     @Query("includeInternal") includeInternal?: boolean,
   ): Promise<ThreadMessageDto[]> {
-    return await this.threadsService.getMessages(threadId, includeInternal);
+    return await this.threadsService.getMessages({ threadId, includeInternal });
   }
 
   @UseGuards(ThreadInProjectGuard)

--- a/apps/api/src/threads/threads.controller.ts
+++ b/apps/api/src/threads/threads.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -216,15 +217,21 @@ export class ThreadsController {
   @Get(":id/messages")
   @ApiQuery({
     name: "includeInternal",
-    description: "Whether to include internal messages",
+    description: "Whether to include internal messages, must be `true`",
     required: false,
     type: Boolean,
+    deprecated: true,
   })
   async getMessages(
     @Param("id") threadId: string,
     @Query("includeInternal") includeInternal?: boolean,
   ): Promise<ThreadMessageDto[]> {
-    return await this.threadsService.getMessages({ threadId, includeInternal });
+    if (!includeInternal === false) {
+      throw new BadRequestException(
+        "includeInternal is deprecated, if passed, it can only be `true`",
+      );
+    }
+    return await this.threadsService.getMessages({ threadId });
   }
 
   @UseGuards(ThreadInProjectGuard)

--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -755,7 +755,7 @@ export class ThreadsService {
       );
 
       if (!suggestions.suggestions.length) {
-        throw new SuggestionGenerationError(messageId);
+        throw new SuggestionGenerationError(`No suggestions for ${messageId}`);
       }
 
       const savedSuggestions = await operations.createSuggestions(
@@ -854,7 +854,6 @@ export class ThreadsService {
 
     const messages = await this.getMessages({
       threadId,
-      includeInternal: false,
     });
     if (messages.length === 0) {
       throw new NotFoundException("No messages found for thread");
@@ -1082,7 +1081,6 @@ export class ThreadsService {
 
       const messages = await this.getMessages({
         threadId: thread.id,
-        includeInternal: true,
         includeSystem: true,
       });
       const project = await operations.getProject(db, projectId);

--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -2215,7 +2215,7 @@ function createMcpHandlers(
 ): MCPHandlers {
   return {
     async sampling(e) {
-      const parentMessageId = e.params._meta?.tamboParentMessageId as
+      const parentMessageId = e.params._meta?.["tambo.co/parentMessageId"] as
         | string
         | undefined;
       const messages = e.params.messages.map((m) => ({

--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -609,11 +609,15 @@ export class ThreadsService {
     return await addMessage(this.getDb(), threadId, messageDto);
   }
 
-  async getMessages(
-    threadId: string,
-    includeInternal: boolean = false,
-    includeSystem: boolean = false,
-  ): Promise<ThreadMessageDto[]> {
+  async getMessages({
+    threadId,
+    includeInternal = false,
+    includeSystem = false,
+  }: {
+    threadId: string;
+    includeInternal?: boolean;
+    includeSystem?: boolean;
+  }): Promise<ThreadMessageDto[]> {
     const messages = await operations.getMessages(
       this.getDb(),
       threadId,
@@ -734,7 +738,9 @@ export class ThreadsService {
         data: { messageId, threadId: message.threadId },
       });
 
-      const threadMessages = await this.getMessages(message.threadId);
+      const threadMessages = await this.getMessages({
+        threadId: message.threadId,
+      });
       const tamboBackend = await this.createTamboBackendForThread(
         message.threadId,
         contextKey,
@@ -846,7 +852,10 @@ export class ThreadsService {
       throw new NotFoundException("Thread not found");
     }
 
-    const messages = await this.getMessages(threadId, false);
+    const messages = await this.getMessages({
+      threadId,
+      includeInternal: false,
+    });
     if (messages.length === 0) {
       throw new NotFoundException("No messages found for thread");
     }
@@ -1071,7 +1080,11 @@ export class ThreadsService {
         `${projectId}-${contextKey ?? TAMBO_ANON_CONTEXT_KEY}`,
       );
 
-      const messages = await this.getMessages(thread.id, true, true);
+      const messages = await this.getMessages({
+        threadId: thread.id,
+        includeInternal: true,
+        includeSystem: true,
+      });
       const project = await operations.getProject(db, projectId);
 
       if (messages.length === 0) {

--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -611,17 +611,17 @@ export class ThreadsService {
 
   async getMessages({
     threadId,
-    includeInternal = false,
     includeSystem = false,
+    includeChildMessages = false,
   }: {
     threadId: string;
-    includeInternal?: boolean;
     includeSystem?: boolean;
+    includeChildMessages?: boolean;
   }): Promise<ThreadMessageDto[]> {
     const messages = await operations.getMessages(
       this.getDb(),
       threadId,
-      includeInternal,
+      includeChildMessages,
     );
     return messages
       .filter((message) => includeSystem || message.role !== MessageRole.System)

--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -1172,6 +1172,7 @@ export class ThreadsService {
         return await this.handleSystemToolCall(
           toolCallRequest,
           responseMessage.toolCallId ?? "",
+          responseMessageDto.id,
           allTools,
           responseMessage,
           advanceRequestDto,
@@ -1212,6 +1213,7 @@ export class ThreadsService {
   private async handleSystemToolCall(
     toolCallRequest: ToolCallRequest,
     toolCallId: string,
+    toolCallMessageId: string,
     allTools: McpToolRegistry,
     componentDecision: LegacyComponentDecision,
     advanceRequestDto: AdvanceThreadDto,
@@ -1223,6 +1225,7 @@ export class ThreadsService {
   private async handleSystemToolCall(
     toolCallRequest: ToolCallRequest,
     toolCallId: string,
+    toolCallMessageId: string,
     allTools: McpToolRegistry,
     componentDecision: LegacyComponentDecision,
     advanceRequestDto: AdvanceThreadDto,
@@ -1234,6 +1237,7 @@ export class ThreadsService {
   private async handleSystemToolCall(
     toolCallRequest: ToolCallRequest,
     toolCallId: string,
+    toolCallMessageId: string,
     allTools: McpToolRegistry,
     componentDecision: LegacyComponentDecision,
     advanceRequestDto: AdvanceThreadDto,
@@ -1260,6 +1264,7 @@ export class ThreadsService {
         await this.handleSystemToolCall_(
           toolCallRequest,
           toolCallId,
+          toolCallMessageId,
           allTools,
           componentDecision,
           advanceRequestDto,
@@ -1274,6 +1279,7 @@ export class ThreadsService {
   private async handleSystemToolCall_(
     toolCallRequest: ToolCallRequest,
     toolCallId: string,
+    toolCallMessageId: string,
     allTools: McpToolRegistry,
     componentDecision: LegacyComponentDecision,
     advanceRequestDto: AdvanceThreadDto,
@@ -1297,6 +1303,7 @@ export class ThreadsService {
         allTools,
         toolCallRequest,
         toolCallId,
+        toolCallMessageId,
         componentDecision,
         advanceRequestDto,
       );
@@ -1867,6 +1874,7 @@ export class ThreadsService {
         const toolResponseMessageStream = await this.handleSystemToolCall(
           toolCallRequest,
           toolCallId ?? "",
+          finalThreadMessage.id,
           allTools,
           componentDecision,
           originalRequest,

--- a/apps/api/src/threads/util/tool.ts
+++ b/apps/api/src/threads/util/tool.ts
@@ -44,6 +44,7 @@ export async function callSystemTool(
   systemTools: McpToolRegistry,
   toolCallRequest: ToolCallRequest,
   toolCallId: string,
+  toolCallMessageId: string,
   componentDecision: LegacyComponentDecision,
   advanceRequestDto: AdvanceThreadDto,
 ) {
@@ -59,7 +60,7 @@ export async function callSystemTool(
     const result = await toolSource.callTool(
       toolCallRequest.toolName,
       params,
-      componentDecision.id,
+      toolCallMessageId,
     );
     const responseContent = buildToolResponseContent(result);
 

--- a/apps/api/src/threads/util/tool.ts
+++ b/apps/api/src/threads/util/tool.ts
@@ -56,7 +56,11 @@ export async function callSystemTool(
         p.parameterValue,
       ]),
     );
-    const result = await toolSource.callTool(toolCallRequest.toolName, params);
+    const result = await toolSource.callTool(
+      toolCallRequest.toolName,
+      params,
+      componentDecision.id,
+    );
     const responseContent = buildToolResponseContent(result);
 
     // TODO: handle cases where MCP server returns *only* resource types

--- a/apps/test-mcp-server/src/index.ts
+++ b/apps/test-mcp-server/src/index.ts
@@ -45,14 +45,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 server.setRequestHandler(
   CallToolRequestSchema,
   async (request: CallToolRequest): Promise<CallToolResult> => {
-    const { name, arguments: args } = request.params;
+    const { name, arguments: args, _meta } = request.params;
 
     const handler = serviceRegistry.getHandler(name);
     if (!handler) {
       throw new Error(`Unknown tool: ${name}`);
     }
 
-    return await handler(args, server);
+    return await handler(args, _meta, server);
   },
 );
 

--- a/apps/test-mcp-server/src/mcp-service.ts
+++ b/apps/test-mcp-server/src/mcp-service.ts
@@ -4,6 +4,7 @@ import { CallToolResult, type Tool } from "@modelcontextprotocol/sdk/types.js";
 // Generic tool handler type
 export type ToolHandler<A = unknown> = (
   args: A,
+  _meta: Record<string, unknown> | undefined,
   server: Server,
 ) => Promise<CallToolResult>;
 

--- a/apps/test-mcp-server/src/test-tools.ts
+++ b/apps/test-mcp-server/src/test-tools.ts
@@ -52,6 +52,7 @@ export const testTools: Tool[] = [
 export const testHandlers = {
   ask_user_for_choice: async (
     args: unknown,
+    _meta: Record<string, unknown> | undefined,
     server: Server,
   ): Promise<CallToolResult> => {
     try {
@@ -76,6 +77,7 @@ export const testHandlers = {
       console.log("Eliciting input", prompt);
 
       const response = await server.elicitInput({
+        _meta,
         message: prompt,
         requestedSchema: {
           type: "object",
@@ -116,6 +118,7 @@ export const testHandlers = {
 
   emojify_via_llm: async (
     args: unknown,
+    _meta: Record<string, unknown> | undefined,
     server: Server,
   ): Promise<CallToolResult> => {
     try {
@@ -135,6 +138,7 @@ export const testHandlers = {
         };
       }
       const response = await server.createMessage({
+        _meta,
         messages: [
           {
             role: "user",

--- a/packages/core/src/mcp-client.ts
+++ b/packages/core/src/mcp-client.ts
@@ -410,7 +410,7 @@ export class MCPClient {
       name,
       arguments: args,
       _meta: {
-        tamboParentMessageId: parentMessageId,
+        ["tambo.co/parentMessageId"]: parentMessageId,
       },
     });
     return result;

--- a/packages/core/src/mcp-client.ts
+++ b/packages/core/src/mcp-client.ts
@@ -404,10 +404,14 @@ export class MCPClient {
   async callTool(
     name: string,
     args: Record<string, unknown>,
+    parentMessageId?: string,
   ): Promise<MCPToolCallResult> {
     const result = await this.client.callTool({
       name,
       arguments: args,
+      _meta: {
+        tamboParentMessageId: parentMessageId,
+      },
     });
     return result;
   }

--- a/packages/db/src/operations/thread.ts
+++ b/packages/db/src/operations/thread.ts
@@ -250,14 +250,14 @@ export async function addMessage(
 export async function getMessages(
   db: HydraDb,
   threadId: string,
-  includeInternal: boolean = false,
+  includeChildMessages: boolean = false,
 ): Promise<(typeof schema.messages.$inferSelect)[]> {
   const messages = await db.query.messages.findMany({
-    where: includeInternal
+    where: includeChildMessages
       ? eq(schema.messages.threadId, threadId)
       : and(
           eq(schema.messages.threadId, threadId),
-          ne(schema.messages.role, MessageRole.Tool),
+          isNull(schema.messages.parentMessageId),
         ),
     orderBy: (messages, { asc }) => [asc(messages.createdAt)],
   });


### PR DESCRIPTION
- **thread through threadId and parentMessageId to sampling calls**
- **thread _meta through in MCP server**
- **properly thread through the right "parent" message id**
- **make getMessages() take an object**
- **do not include "child" messages by default**
- **remove includeInternal from internal api**
