### PR TITLE
chore(deps): Bump @modelcontextprotocol/sdk

### DIFF
--- a/apps/api/src/mcp-server/prompts.ts
+++ b/apps/api/src/mcp-server/prompts.ts
@@ -1,16 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { MCPClient } from "@tambo-ai-cloud/core";
-import Ajv from "ajv";
 import { z } from "zod";
-
-const ajv = new Ajv();
-
-/** This is just a wrapper around ajv to convert a JSON schema to a Zod type. */
-function zodFromJsonSchema(jsonSchema: object): z.ZodTypeAny {
-  const validateFn = ajv.compile(jsonSchema);
-  return z.custom((data) => validateFn(data));
-}
 
 export async function registerPromptHandlers(
   server: McpServer,
@@ -32,9 +23,7 @@ export async function registerPromptHandlers(
         for (const prompt of promptResponse.prompts) {
           const argsSchema = Object.fromEntries(
             prompt.arguments?.map((arg) => {
-              const argZod = zodFromJsonSchema({
-                type: arg.type ?? "string",
-              });
+              const argZod = z.string();
               const requiredArgZod = arg.required ? argZod : argZod.optional();
               return [arg.name, requiredArgZod] as const;
             }) ?? [],

--- a/apps/api/src/mcp-server/server.ts
+++ b/apps/api/src/mcp-server/server.ts
@@ -32,7 +32,6 @@ export async function createMcpServer(
     {
       capabilities: {
         prompts: { listChanged: true },
-        elicitation: {},
       },
       // Enable notification debouncing for specific methods
       debouncedNotificationMethods: [

--- a/apps/test-mcp-server/src/test-prompts.ts
+++ b/apps/test-mcp-server/src/test-prompts.ts
@@ -5,8 +5,12 @@ export const testPrompts: Prompt[] = [
     name: "test_prompt",
     title: "Test Prompt",
     description: "A test prompt",
-    inputSchema: {
-      type: "object",
-    },
+    arguments: [
+      {
+        name: "test_arg",
+        description: "A test argument",
+        required: true,
+      },
+    ],
   },
 ];

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -131,6 +131,9 @@ const config = {
       },
     ],
   },
+  experimental: {
+    webpackMemoryOptimizations: true,
+  },
   // Configure webpack to use SVGR for SVG imports
   webpack(config) {
     // Modify the rules for SVG files

--- a/package-lock.json
+++ b/package-lock.json
@@ -8859,9 +8859,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.21.1.tgz",
-      "integrity": "sha512-UyLFcJLDvUuZbGnaQqXFT32CpPpGj7VS19roLut6gkQVhb439xUzYWbsUvdI3ZPL+2hnFosuugtYWE0Mcs1rmQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.22.0.tgz",
+      "integrity": "sha512-VUpl106XVTCpDmTBil2ehgJZjhyLY2QZikzF8NvTXtLRF1CvO5iEE2UNZdVIUer35vFOwMKYeUGbjJtvPWan3g==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",


### PR DESCRIPTION
I accidentally bumped the package version and it triggered a bunch of type issues, so I spun that out to a separate pr

Also in here is a minor webpack thing, my dev server was taking up 8G of RAM, this has helped...

- **bump @modelcontextprotocol/sdk**
- **stricter types from new sdk**
- **try to reduce nextjs memory use**
